### PR TITLE
chore: Update ESLint configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     '@typescript-eslint',
   ],
   rules: {
+    'eol-last': 'off',
     semi: ['error', 'never'],
     'implicit-arrow-linebreak': 'off',
     'import/extensions': [
@@ -31,6 +32,9 @@ module.exports = {
         tsx: 'never',
       },
     ],
+    'import/prefer-default-export': 'off',
+    indent: 'off',
+    'object-curly-newline': 'off',
   },
   settings: {
     'import/parsers': {


### PR DESCRIPTION
This turns off `import/prefer-default-export`, as it can lead to the same function having multiple names in the code base, and also doesn't allow for a second export to be added to a module.

It also disables a few rules not needed with the formatting being strictly checked.