### PR TITLE
ci: Set reviewers for Dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       - dependencies
     commit-message:
       prefix: 'deps:'
+    reviewers:
+      - adamledwards
+      - jpveooys
 
   - package-ecosystem: github-actions
     directory: /
@@ -18,3 +21,6 @@ updates:
       - ci
     commit-message:
       prefix: 'ci:'
+    reviewers:
+      - adamledwards
+      - jpveooys


### PR DESCRIPTION
This updates the Dependabot configuration so that reviewers are set on Dependabot PRs.

(Although switching to Renovate might be better as it supports batching.)