### PR TITLE
chore: Correct CODEOWNERS syntax and content

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
--       @jpveooys
--       @adamledwards
+*       @jpveooys @adamledwards


### PR DESCRIPTION
The CODEOWNERS syntax and content wasn't quite right, hence it wasn't having the right effect.

See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax