### PR TITLE
ci: Move fixup! check to a separate job

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -41,6 +41,16 @@ jobs:
         run: |
           npm exec --no -- commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
+  check-for-fixup-commits:
+    name: Check for fixup! commits
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: Check for fixup! commits
         shell: bash
         run: |


### PR DESCRIPTION
This moves the fixup! commit check to a separate job, so the reason for a workflow failure is clearer.