### PR TITLE
chore: Use node: protocol for Node.js imports

### DIFF
--- a/examples-server/serve.ts
+++ b/examples-server/serve.ts
@@ -2,8 +2,8 @@
 import fastifyStatic from '@fastify/static'
 import fastifyView from '@fastify/view'
 import fastify from 'fastify'
+import path from 'node:path'
 import nunjucks, { Environment } from 'nunjucks'
-import path from 'path'
 
 import { addMODUKFilters, getNunjucksPaths } from '../src'
 import { findExamples } from '../src/test-utils'

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { get, set } from 'lodash'
+import { dirname, join } from 'node:path'
 import { configure, ConfigureOptions, Environment } from 'nunjucks'
-import { dirname, join } from 'path'
 
 /**
  * Get the template paths that should be specified when manually creating a new


### PR DESCRIPTION
This updates the last two imports that weren't using the [`node:` protocol](https://nodejs.org/api/esm.html#esm_node_imports) to use the protocol, for clarity and future compatibility.