### PR TITLE
ci: Use sharding when running end-to-end tests

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -87,13 +87,17 @@ jobs:
           echo "version=$(scripts/get-playwright-version.sh)" >> "$GITHUB_OUTPUT"
 
   test-e2e:
-    name: Run e2e tests
+    name: Run e2e tests (${{ matrix.shard }}/${{ matrix.total_shards }})
     runs-on: ubuntu-22.04
     needs:
       - read-playwright-version
     container:
       image: mcr.microsoft.com/playwright:${{ needs.read-playwright-version.outputs.version }}-jammy
       options: --user 1001
+    strategy:
+      matrix:
+        shard: [1, 2, 3]
+        total_shards: [3]
     steps:
       - name: Git clone repository
         uses: actions/checkout@v3
@@ -102,12 +106,12 @@ jobs:
         uses: ./.github/actions/prepare-environment
 
       - name: Run e2e tests
-        run: npm run test:e2e
+        run: npm run test:e2e -- --shard ${{ matrix.shard }}/${{ matrix.total_shards }}
 
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: e2e-test-results
+          name: e2e-test-results-${{ matrix.shard }}
           path: e2e/output
 
   test-visual-regression:


### PR DESCRIPTION
As the end-to-end tests are now taking about four minutes to run on GitHub Actions, this changes the GitHub Actions workflow so that three shards are used.

Results are reported independently for each shard.

# Before

![image](https://user-images.githubusercontent.com/66470099/205685495-73daed8f-cf36-4057-bf42-a869827546ba.png)

![image](https://user-images.githubusercontent.com/66470099/205696537-f29b8416-42f3-42dc-a967-4413f487e3cf.png)

# After

![image](https://user-images.githubusercontent.com/66470099/205696732-313eccd0-78e4-4a3b-942c-08f973a75836.png)

![image](https://user-images.githubusercontent.com/66470099/205696404-8db20cba-05f6-4d05-9562-a4bd76783151.png)

