### PR TITLE
chore: Fix commitlint parsing of deps-dev type

### DIFF
--- a/.release-it.js
+++ b/.release-it.js
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const commitlintConfig = require('./commitlint.config')
+
 module.exports = {
   git: {
     // eslint-disable-next-line no-template-curly-in-string
@@ -20,6 +23,7 @@ module.exports = {
   },
   plugins: {
     '@release-it/conventional-changelog': {
+      parserOpts: commitlintConfig.parserPreset.parserOpts,
       preset: {
         name: 'conventionalcommits',
         types: [

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,10 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  parserPreset: {
+    parserOpts: {
+      headerPattern: /^([^():]*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$/,
+    },
+  },
   rules: {
     'subject-case': [1, 'always', 'sentence-case'],
     'body-max-line-length': [0],


### PR DESCRIPTION
By default, commitlint doesn't handle types containing a hyphen.

This configures a custom `headerPattern` to make it work. See https://github.com/conventional-changelog/commitlint/issues/2694 for more detail (the regex used was based on the current default).

To test locally, you can run e.g. `echo 'deps-dev: fff' | commitlint`.