### PR TITLE
fix: Add support for call blocks to various components

### DIFF
--- a/src/nunjucks/moduk/components/details/__tests__/macro.test.js
+++ b/src/nunjucks/moduk/components/details/__tests__/macro.test.js
@@ -1,9 +1,0 @@
-import { describe, expect, it } from 'vitest'
-
-import { renderFile } from '../../../../../test-utils'
-
-describe('Details', async () => {
-  it('renders the content', () => {
-    expect(() => renderFile('moduk/components/details/__examples__/default.njk')).not.toThrowError()
-  })
-})

--- a/src/nunjucks/moduk/components/details/__tests__/macro.test.ts
+++ b/src/nunjucks/moduk/components/details/__tests__/macro.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { render, renderFile } from '../../../../../test-utils'
+
+describe('Details', async () => {
+  it('renders the content when using the text property', () => {
+    const element = renderFile('moduk/components/details/__examples__/default.njk')
+    expect(element).toHaveTextContent('We need to know the organisation')
+  })
+
+  it('renders the content when using the html property', () => {
+    const element = render(`
+{% from "moduk/components/details/macro.njk" import modukDetails %}
+
+{{ modukDetails({
+  summaryText: "Help with organisation",
+  html: "We need to know the organisation you work for so we can forward your request to the correct team."
+}) }}
+`)
+    expect(element).toHaveTextContent('We need to know the organisation')
+  })
+
+  it('renders the content when using a call block', () => {
+    const element = render(`
+{% from "moduk/components/details/macro.njk" import modukDetails %}
+
+{% call modukDetails({
+  summaryText: "Help with organisation" 
+}) %}
+  We need to know the organisation<br>you work for so we can forward your request to the correct team.
+{% endcall %}
+`)
+    expect(element).toContainHTML('We need to know the organisation<br>you')
+  })
+})

--- a/src/nunjucks/moduk/components/details/macro.njk
+++ b/src/nunjucks/moduk/components/details/macro.njk
@@ -1,5 +1,11 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
-{% macro modukDetails(params) %}
-  {{ govukDetails(params) }}
-{% endmacro %}
+{% macro modukDetails(params) -%}
+  {% if caller -%}
+    {% call govukDetails(params) -%}
+      {{ caller() }}
+    {%- endcall %}
+  {%- else -%}
+    {{ govukDetails(params) }}
+  {%- endif %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/inset-text/__tests__/macro.test.ts
+++ b/src/nunjucks/moduk/components/inset-text/__tests__/macro.test.ts
@@ -1,9 +1,35 @@
 import { describe, expect, it } from 'vitest'
 
-import { renderFile } from '../../../../../test-utils'
+import { render, renderFile } from '../../../../../test-utils'
 
 describe('Inset text', async () => {
-  it('renders the content', () => {
-    expect(() => renderFile('moduk/components/inset-text/__examples__/default.njk')).not.toThrowError()
+  it('renders the content when using the text property', () => {
+    const element = renderFile('moduk/components/inset-text/__examples__/default.njk')
+    expect(element).toHaveTextContent('You’ll get confirmation')
+  })
+
+  it('renders the content when using the html property', () => {
+    const element = render(`
+{% from "moduk/components/inset-text/macro.njk" import modukInsetText %}
+
+{{ modukInsetText({
+  summaryText: "Help with organisation",
+  html: "You’ll get confirmation that we have received your report within 5 working days."
+}) }}
+`)
+    expect(element).toHaveTextContent('You’ll get confirmation')
+  })
+
+  it('renders the content when using a call block', () => {
+    const element = render(`
+{% from "moduk/components/inset-text/macro.njk" import modukInsetText %}
+
+{% call modukInsetText({
+  summaryText: "Help with organisation" 
+}) %}
+  You’ll get confirmation<br> that we have received your report within 5 working days.
+{% endcall %}
+`)
+    expect(element).toContainHTML('You’ll get confirmation<br> that')
   })
 })

--- a/src/nunjucks/moduk/components/inset-text/macro.njk
+++ b/src/nunjucks/moduk/components/inset-text/macro.njk
@@ -1,5 +1,11 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
-{% macro modukInsetText(params) %}
-  {{ govukInsetText(params) }}
-{% endmacro %}
+{% macro modukInsetText(params) -%}
+  {% if caller -%}
+    {% call govukInsetText(params) -%}
+      {{ caller() }}
+    {%- endcall %}
+  {%- else -%}
+    {{ govukInsetText(params) }}
+  {%- endif %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/notification-banner/__tests__/macro.test.ts
+++ b/src/nunjucks/moduk/components/notification-banner/__tests__/macro.test.ts
@@ -1,9 +1,32 @@
 import { describe, expect, it } from 'vitest'
 
-import { renderFile } from '../../../../../test-utils'
+import { render, renderFile } from '../../../../../test-utils'
 
 describe('Notification banner', async () => {
-  it('renders the content', () => {
-    expect(() => renderFile('moduk/components/notification-banner/__examples__/default.njk')).not.toThrowError()
+  it('renders the content when using the text property', () => {
+    const element = renderFile('moduk/components/notification-banner/__examples__/default.njk')
+    expect(element).toHaveTextContent('There may be a delay')
+  })
+
+  it('renders the content when using the html property', () => {
+    const element = render(`
+{% from "moduk/components/notification-banner/macro.njk" import modukNotificationBanner %}
+
+{{ modukNotificationBanner({
+  html: "There may be a delay in processing your application because of the coronavirus outbreak."
+}) }}
+`)
+    expect(element).toHaveTextContent('There may be a delay')
+  })
+
+  it('renders the content when using a call block', () => {
+    const element = render(`
+{% from "moduk/components/notification-banner/macro.njk" import modukNotificationBanner %}
+
+{% call modukNotificationBanner({}) %}
+  There may be a delay<br> in processing your application because of the coronavirus outbreak.
+{% endcall %}
+`)
+    expect(element).toContainHTML('There may be a delay<br> in')
   })
 })

--- a/src/nunjucks/moduk/components/notification-banner/macro.njk
+++ b/src/nunjucks/moduk/components/notification-banner/macro.njk
@@ -1,5 +1,11 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
-{% macro modukNotificationBanner(params) %}
-  {{ govukNotificationBanner(params) }}
-{% endmacro %}
+{% macro modukNotificationBanner(params) -%}
+  {% if caller -%}
+    {% call govukNotificationBanner(params) -%}
+      {{ caller() }}
+    {%- endcall %}
+  {%- else -%}
+    {{ govukNotificationBanner(params) }}
+  {%- endif %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/panel/__tests__/macro.test.ts
+++ b/src/nunjucks/moduk/components/panel/__tests__/macro.test.ts
@@ -1,9 +1,35 @@
 import { describe, expect, it } from 'vitest'
 
-import { renderFile } from '../../../../../test-utils'
+import { render, renderFile } from '../../../../../test-utils'
 
 describe('Panel', async () => {
-  it('renders the content', () => {
-    expect(() => renderFile('moduk/components/panel/__examples__/default.njk')).not.toThrowError()
+  it('renders the content using the html property', () => {
+    const element = renderFile('moduk/components/panel/__examples__/default.njk')
+    expect(element).toHaveTextContent('HDJ2123F')
+  })
+
+  it('renders the content when using the text property', () => {
+    const element = render(`
+{% from "moduk/components/panel/macro.njk" import modukPanel %}
+
+{{ modukPanel({
+  titleText: "Application complete",
+  text: "Your reference number is HDJ2123F"
+}) }}
+`)
+    expect(element).toHaveTextContent('HDJ2123F')
+  })
+
+  it('renders the content when using a call block', () => {
+    const element = render(`
+{% from "moduk/components/panel/macro.njk" import modukPanel %}
+
+{% call modukPanel({
+  titleText: "Application complete" 
+}) %}
+  Your reference number<br><strong>HDJ2123F</strong>
+{% endcall %}
+`)
+    expect(element).toContainHTML('Your reference number<br><strong>HDJ2123F</strong>')
   })
 })

--- a/src/nunjucks/moduk/components/panel/macro.njk
+++ b/src/nunjucks/moduk/components/panel/macro.njk
@@ -1,5 +1,11 @@
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
-{% macro modukPanel(panel) %}
-  {{ govukPanel(panel) }}
-{% endmacro %}
+{% macro modukPanel(params) -%}
+  {% if caller -%}
+    {% call govukPanel(params) -%}
+      {{ caller() }}
+    {%- endcall %}
+  {%- else -%}
+    {{ govukPanel(params) }}
+  {%- endif %}
+{%- endmacro %}


### PR DESCRIPTION
This makes various existing components work correctly when a [call block](https://mozilla.github.io/nunjucks/templating.html#call) is used.

The only other component that supports call blocks is error summary (which we haven't implemented yet).