### PR TITLE
build(npm): Configure files to publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "dist/lib/index.js",
   "sass": "src/css/index.scss",
   "style": "dist/css/index.css",
+  "files": [
+    "dist",
+    "src/css"
+  ],
   "exports": {
     ".": {
       "types": "./dist/lib/index.d.ts",


### PR DESCRIPTION
This configures the `files` property in `package.json` to avoid unwanted files being included in the published package.