### PR TITLE
ci: Fix npm publish step in release workflow

### DIFF
--- a/.github/actions/prepare-environment/action.yml
+++ b/.github/actions/prepare-environment/action.yml
@@ -5,8 +5,9 @@ runs:
   steps:
     - uses: actions/setup-node@v3
       with:
-        node-version-file: .nvmrc
         cache: npm
+        node-version-file: .nvmrc
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
The registry URL needs to be explicitly set when using the setup-node action as this configures npm to use the NODE_AUTH_TOKEN environment variable for authentication (via a `.npmrc` file).