### PR TITLE
ci(dependabot): Set npm versioning-strategy to increase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    versioning-strategy: increase
     open-pull-requests-limit: 5
     labels:
       - dependencies


### PR DESCRIPTION
Dependabot currently seems to only update `package-lock.json` (and not `package.json`) for dev dependencies.

This configures [`versioning-strategy`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy) to hopefully make it update `package.json` as well.