### PR TITLE
ci(preview-link): Vite Plugin for ssg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ typings/
 # Nuxt.js build / generate output
 .nuxt
 dist
+_site/
 
 # Gatsby files
 .cache/

--- a/dprint.json
+++ b/dprint.json
@@ -5,21 +5,22 @@
     "quoteStyle": "preferSingle",
     "quoteProps": "asNeeded"
   },
-  "json": {
-  },
+  "json": {},
   "markdown": {
     "textWrap": "always"
   },
-  "dockerfile": {
-  },
+  "dockerfile": {},
   "prettier": {
     "bracketSpacing": true,
     "semi": false,
     "singleQuote": true,
     "trailingComma": "es5"
   },
-  "includes": ["**/*.{ts,tsx,js,jsx,cjs,mjs,json,md,dockerfile,html,css,sass,scss,yml,yaml}"],
+  "includes": [
+    "**/*.{ts,tsx,js,jsx,cjs,mjs,json,md,dockerfile,html,css,sass,scss,yml,yaml}"
+  ],
   "excludes": [
+    "_site",
     "dist",
     "**/node_modules",
     "**/*-lock.json"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prebuild:assets": "shx rm -rf dist/assets",
     "build:assets": "ts-node scripts/copy-govuk-static-assets.ts",
     "build:client": "vite build && tsc --project src/client",
+    "build:ssg": "npm run build && vite build -c vite.pages.config.ts",
     "prebuild:css": "shx rm -rf dist/css",
     "build:css": "sass --load-path=node_modules --quiet-deps --style compressed src/css/index.scss | postcss -o dist/css/index.css",
     "prebuild:lib": "shx rm -rf dist/lib",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "_site", "node_modules"]
 }

--- a/vite.pages.config.ts
+++ b/vite.pages.config.ts
@@ -1,0 +1,94 @@
+import { keyBy, mapValues } from 'lodash'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { defineConfig, PluginOption } from 'vite'
+
+import { createNunjucksEnvironment } from './src'
+import { findExamples } from './src/test-utils'
+
+const examples = findExamples()
+
+const env = createNunjucksEnvironment([path.join(__dirname, 'examples-server', 'templates')])
+
+type Page = {
+  permalink: string
+  template: string
+  context: object
+}
+
+const generateHtmlPlugin = (context: Page[]): PluginOption => {
+  const pages = keyBy(context, (page) => page.permalink)
+  return {
+    name: 'generate:mod-preview',
+    config() {
+      return {
+        build: {
+          rollupOptions: {
+            input: mapValues(pages, (page) => page.permalink),
+            onwarn: (warning, defaultHandler) => {
+              if (warning.message.match('Generated an empty chunk:')) return
+              defaultHandler(warning)
+            },
+          },
+        },
+      }
+    },
+    resolveId(id) {
+      if (pages[id]) {
+        return id
+      }
+      return null
+    },
+    load(id) {
+      if (pages[id]) {
+        return 'noop'
+      }
+      return null
+    },
+    transform(_code, id) {
+      if (pages[id]) {
+        return env.render(pages[id].template, pages[id].context)
+      }
+      return null
+    },
+  }
+}
+
+/* Ignoring for not because we need to change the tsconfig target to ise flatMap */
+/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+// @ts-ignore
+const examplePages = examples.flatMap(([componentName, exampleNames]: [string, string[]]) => (
+  exampleNames.map((exampleName) => ({
+    permalink: `components/${componentName}/${exampleName}/index.html`,
+    template: 'example.njk',
+    context: { template: `moduk/components/${componentName}/__examples__/${exampleName}.njk` },
+  }))
+))
+
+export default defineConfig({
+  build: {
+    outDir: './_site',
+    rollupOptions: {
+      input: '',
+    },
+  },
+  publicDir: './dist/',
+  plugins: [
+    generateHtmlPlugin([
+      {
+        permalink: 'index.html',
+        template: 'index.njk',
+        context: { examples },
+      },
+      ...examplePages,
+    ]),
+    {
+      name: 'remove:lib',
+      async closeBundle() {
+        // Remove the lib folder from the public dir
+
+        return fs.rm(path.resolve(__dirname, '_site', 'lib'), { recursive: true })
+      },
+    },
+  ],
+})


### PR DESCRIPTION
The nunjunks plugins didn't really work, but looking at the source code there really not much to them.
They require a physical entry point which our app only has the index.html. I used vite's plugin API to create virtual file and our existing nunjunks helpers.
![Screen Recording 2022-12-14 at 17 43 00 2022-12-14 17_56_58](https://user-images.githubusercontent.com/5575331/207671253-7686a4dc-d35c-4672-b84b-47025923e08c.gif)
