### PR TITLE
chore(GitHub): Add issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Report a bug or regression
+labels:
+  - bug
+  - awaiting triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You’re reporting a bug in MOD.UK Frontend. All questions are optional – fill in as much of the form as you’re able to.
+
+        All issues created in this repository are public. Do not include any sensitive information.
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: What steps will reproduce the bug?
+      description: Include a code snippet or public link if relevant
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened instead?
+      description: Attach a screenshot or screen recording if relevant
+  - type: input
+    id: version
+    attributes:
+      label: What version of MOD.UK Frontend were you using?
+      description: The version of the @moduk/frontend package the problem was seen in
+  - type: textarea
+    id: browser-os
+    attributes:
+      label: What web browsers and operating systems were you using?
+      description: For example, Firefox 108 on Windows 10 and Chrome 105 on Android 13
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Context and anything else
+      description: What are you trying to accomplish? How has this issue affected you? Do you have a suggested fix?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest a new feature or an enhancement
+labels:
+  - enhancement
+  - awaiting triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You’re suggesting a feature to add to MOD.UK Frontend. All questions are optional – fill in as much of the form as you’re able to.
+
+        All issues created in this repository are public. Do not include any sensitive information.
+  - type: input
+    id: related-component
+    attributes:
+      label: Related components
+      description: The names of any existing components that this request relates to
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What are you trying to do? Is this something you think should behave differently, or something that you currently cannot do?
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: Are you using or have you tried any alternatives or workarounds?
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Anything else
+      description: Any other information that you think is relevant. Include details of any user research you’ve done on this feature


### PR DESCRIPTION
This adds issue form templates for bugs and feature requests.

Inspiration has been drawn from other repos, including GOV.UK Frontend.

I've also put the forms in a test repo, so they can been seen here: https://github.com/jpveooys/github-actions-testing-v2/issues/new/choose

See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms and https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema for details on the schema for the YAML file.