### PR TITLE
feat: Rename client JavaScript bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ initAll()
 ```
 
 In older environments, you may need to import the client-side library from
-`@moduk/frontend/dist/client/MODUK.umd.js`.
+`@moduk/frontend/dist/client/moduk-frontend.umd.js`.
 
 ### Importing the CSS
 

--- a/examples-site/example.njk
+++ b/examples-site/example.njk
@@ -18,7 +18,7 @@ permalink: 'components/{{ example.component }}/{{ example.exampleName }}/index.h
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
   </script>
   <div id="root">{% include example.template %}</div>
-  <script src="/client/MODUK.umd.js"></script>
+  <script src="/client/moduk-frontend.umd.js"></script>
   <script>
     window.MODUK.initAll()
   </script>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "import": "./dist/client/moduk-frontend.mjs",
       "require": "./dist/client/moduk-frontend.umd.js"
     },
-    "./dist/": "./dist/"
+    "./dist/*": "./dist/*"
   },
   "types": "dist/lib/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
       "style": "./dist/css/index.css"
     },
     "./client": {
-      "import": "./dist/client/MODUK.mjs",
-      "require": "./dist/client/MODUK.umd.js"
+      "import": "./dist/client/moduk-frontend.mjs",
+      "require": "./dist/client/moduk-frontend.umd.js"
     },
     "./dist/": "./dist/"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     lib: {
       entry: './src/client/index.ts',
       name: 'MODUK',
-      fileName: 'MODUK',
+      fileName: 'moduk-frontend',
     },
     outDir: './dist/client',
   },


### PR DESCRIPTION
This updates the name of the client bundle from `MODUK.umd.js` and `MODUK.mjs` to `moduk-frontend.umd.js` and `moduk-frontend.mjs` so that it has a more meaningful and conventional name.

It also corrects the `./dist/` package.json exports entry – it should have an asterisk in it: https://nodejs.org/api/packages.html#subpath-patterns (doesn't seem to matter for Webpack, but does for Node).