### PR TITLE
fix: Make govuk-frontend a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.2.1-alpha.4",
       "license": "MIT",
       "dependencies": {
-        "govuk-frontend": "^4.4.1",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -52,6 +51,7 @@
         "npm": ">=8.15.0"
       },
       "peerDependencies": {
+        "govuk-frontend": "^4.4.1",
         "nunjucks": "^3.2.3"
       }
     },
@@ -6216,6 +6216,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz",
       "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==",
+      "peer": true,
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -18135,7 +18136,8 @@
     "govuk-frontend": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz",
-      "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA=="
+      "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==",
+      "peer": true
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -124,10 +124,10 @@
     "liquidjs": "^10.4.0"
   },
   "dependencies": {
-    "govuk-frontend": "^4.4.1",
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
+    "govuk-frontend": "^4.4.1",
     "nunjucks": "^3.2.3"
   },
   "publishConfig": {


### PR DESCRIPTION
This PR changes govuk-frontend to a peer dependency. 