### PR TITLE
ci(release): Release non-alpha versions only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,22 +3,10 @@ name: Release
 concurrency:
   group: ${{ github.workflow }}
 
-env:
-  release-type: ${{ inputs.release-type || 'alpha' }}
-
 on:
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch:
-    inputs:
-      release-type:
-        description: 'Release type'
-        required: true
-        default: alpha
-        type: choice
-        options:
-          - alpha
-          - stable
 
 jobs:
   release:
@@ -39,7 +27,7 @@ jobs:
       - id: check-release-required
         name: Check if release required
         run: |
-          VERSION_REGEX=^v[0-9]+\.[0-9]+\.[0-9]+${{ env.release-type == 'stable' && '$' || '-alpha\.[0-9]+$' }}
+          VERSION_REGEX=^v[0-9]+\.[0-9]+\.[0-9]+$
           echo "continue=$(! [[ `git describe --match 'v[0-9]*' --exact-match` =~ $VERSION_REGEX ]] && echo 1)" >> "$GITHUB_OUTPUT"
 
       - name: Configure Git user
@@ -53,7 +41,7 @@ jobs:
         if: steps.check-release-required.outputs.continue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run release:${{ env.release-type }}
+        run: npm run release
 
       - id: git-branch
         if: steps.check-release-required.outputs.continue
@@ -81,7 +69,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm run release:${{ env.release-type }} -- --no-increment --no-git --npm.publish --npm.skipChecks --github.release
+        run: npm run release -- --no-increment --no-git --npm.publish --npm.skipChecks --github.release
 
       - name: Delete release branch
         if: always() && steps.check-release-required.outputs.continue && steps.git-branch.outputs.git-branch

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "npm": ">=8.15.0"
       },
       "peerDependencies": {
-        "govuk-frontend": "^4.4.1",
+        "govuk-frontend": "4.4.1",
         "nunjucks": "^3.2.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "test:visual:refresh": "scripts/run-playwright-container.sh bash -c 'npm install && npm run test:visual:native -- --update-snapshots'",
     "test:watch": "vitest",
     "prepare": "husky install",
-    "release:alpha": "release-it --preRelease=alpha",
-    "release:stable": "release-it --github.draft"
+    "release": "release-it"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "govuk-frontend": "^4.4.1",
+    "govuk-frontend": "4.4.1",
     "nunjucks": "^3.2.3"
   },
   "publishConfig": {


### PR DESCRIPTION
As the library has now gone through internal testing, this makes the release workflow release normal, non-alpha versions. This will eliminate any related friction when testing with users.

The ability to release an alpha version has been removed completely, as it doesn't fit in with the automated release process.

I've given this a quick test in https://github.com/jpveooys/github-actions-testing-v2.

This also pins `govuk-frontend` to a fixed version, as parts of it are bundled so it doesn't make sense to allow a different version of it to be used.