### PR TITLE
chore(deps): Ensure consistent Playwright version is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,9 @@
     ]
   },
   "overrides": {
+    "@axe-core/playwright": {
+      "playwright": "$@playwright/test"
+    },
     "liquidjs": "^10.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
When `@playwright/test` is updated by Dependabot, we tend to have problems as `@axe-core/playwright` has a dependency on `playwright` and the versions get out of sync.

This adds an override to make sure `@axe-core/playwright` uses the same version of Playwright as the project to make updates less painful.