### PR TITLE
Update lint-staged and dprint configurations

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -18,11 +18,11 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
-  "includes": ["**/*.{ts,tsx,js,jsx,cjs,mjs,json,md,dockerfile,html,css,sass,scss,yml,yaml}"],
+  "includes": ["*.{ts,tsx,mts,js,jsx,cjs,mjs,json,md,dockerfile,html,css,sass,scss,yml,yaml}"],
   "excludes": [
-    "dist",
-    "**/node_modules",
-    "**/*-lock.json"
+    "dist/",
+    "node_modules/",
+    "*-lock.json"
   ],
   "plugins": [
     "https://plugins.dprint.dev/typescript-0.77.0.wasm",

--- a/dprint.json
+++ b/dprint.json
@@ -25,10 +25,10 @@
     "*-lock.json"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.77.0.wasm",
-    "https://plugins.dprint.dev/json-0.16.0.wasm",
-    "https://plugins.dprint.dev/markdown-0.14.1.wasm",
+    "https://plugins.dprint.dev/typescript-0.80.2.wasm",
+    "https://plugins.dprint.dev/json-0.17.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.15.2.wasm",
     "https://plugins.dprint.dev/dockerfile-0.3.0.wasm",
-    "https://plugins.dprint.dev/prettier-0.13.0.json@dc5d12b7c1bf1a4683eff317c2c87350e75a5a3dfcc127f3d5628931bfb534b1"
+    "https://plugins.dprint.dev/prettier-0.18.0.json@d2284e34296b93f201f6748afe606edd1cc28d4d28f6a7a75d2d77f7c0e058fd"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -121,8 +121,8 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "eslint --max-warnings 0",
-      "dprint fmt"
+      "dprint fmt",
+      "eslint --max-warnings 0"
     ],
     "*.{md,yaml,yml}": [
       "dprint fmt"

--- a/package.json
+++ b/package.json
@@ -120,11 +120,11 @@
     "webpack-cli": "^5.0.1"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
+    "*.{cjs,js,jsx,mjs,mts,ts,tsx}": [
       "dprint fmt",
       "eslint --max-warnings 0"
     ],
-    "*.{md,yaml,yml}": [
+    "*.{md,scss,yaml,yml}": [
       "dprint fmt"
     ]
   },


### PR DESCRIPTION
This:

- updates the lint-staged config to format before linting. This makes more sense as formatting can fix things flagged by the linter, and the linter doesn't modify files
- adds missing file extensions to the lint-staged config
- simplifies the file patterns in `dprint.json`, as these were more complicated than necessary
- adds `.mts` to `dprint.json` as well
- updates all dprint plugins

dprint plugins were updated using `dprint config update`.

`dprint output-file-paths` can be used to check which files are being checked by dprint.