### PR TITLE
feat(sass): Add `moduk-colour` function and additional MOD colours

### DIFF
--- a/src/css/_colour-palette.scss
+++ b/src/css/_colour-palette.scss
@@ -1,0 +1,15 @@
+$moduk-colours: (
+  'maroon': #532a45,
+  'dark-maroon': #4b263e,
+  'light-maroon': #643f58,
+);
+
+@function moduk-colour($colour-name) {
+  $quoted-colour-name: quote($colour-name);
+
+  @if not map-has-key($moduk-colours, $quoted-colour-name) {
+    @error "Unknown colour `#{$quoted-colour-name}`";
+  }
+
+  @return map-get($moduk-colours, $quoted-colour-name);
+}

--- a/src/css/_variables.scss
+++ b/src/css/_variables.scss
@@ -1,7 +1,10 @@
+@forward './colour-palette';
+@use './colour-palette';
+
 $moduk-assets-path: '/assets/' !default;
 $moduk-images-path: '#{$moduk-assets-path}images/' !default;
 
 $moduk-font-family: 'Hevetica Neue', 'Arial', 'sans-serif' !default;
 
-$moduk-brand-colour: #532a45 !default;
+$moduk-brand-colour: colour-palette.moduk-colour('maroon') !default;
 $moduk-header-link-active: #af6098 !default;

--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -1,3 +1,5 @@
+@forward 'colour-palette';
+
 @forward 'variables';
 @use 'variables';
 


### PR DESCRIPTION
This adds a `moduk-colour()` function and additional colours to the Sass framework.

(We may want to think about how to unit test Sass functions if we start adding more.)