### PR TITLE
chore(checkboxes): Make example `id` attributes unique

### DIFF
--- a/src/nunjucks/moduk/components/checkboxes/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/checkboxes/__examples__/default.njk
@@ -1,7 +1,7 @@
 {% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes %}
 
 {{ modukCheckboxes({
-  name: "technologies",
+  name: "technologies-default",
   fieldset: {
     legend: {
       text: "Which technologies do you use in your role?",

--- a/src/nunjucks/moduk/components/checkboxes/__examples__/not-as-page-heading.njk
+++ b/src/nunjucks/moduk/components/checkboxes/__examples__/not-as-page-heading.njk
@@ -1,7 +1,7 @@
 {% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes %}
 
 {{ modukCheckboxes({
-  name: "technologies",
+  name: "technologies-not-as-page-heading",
   fieldset: {
     legend: {
       text: "Which technologies do you use in your role?"

--- a/src/nunjucks/moduk/components/checkboxes/__examples__/small.njk
+++ b/src/nunjucks/moduk/components/checkboxes/__examples__/small.njk
@@ -1,7 +1,7 @@
 {% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes %}
 
 {{ modukCheckboxes({
-  name: "organisation",
+  name: "organisation-small",
   classes: "govuk-checkboxes--small",
   fieldset: {
     legend: {

--- a/src/nunjucks/moduk/components/checkboxes/__examples__/with-conditional-reveal.njk
+++ b/src/nunjucks/moduk/components/checkboxes/__examples__/with-conditional-reveal.njk
@@ -42,7 +42,7 @@
 {% endset -%}
 
 {{ modukCheckboxes({
-  name: "contact",
+  name: "contact-with-conditional-reveal",
   fieldset: {
     legend: {
       text: "How would you like to be contacted?",

--- a/src/nunjucks/moduk/components/checkboxes/__examples__/with-error-message.njk
+++ b/src/nunjucks/moduk/components/checkboxes/__examples__/with-error-message.njk
@@ -1,7 +1,7 @@
 {% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes %}
 
 {{ modukCheckboxes({
-  name: "technologies",
+  name: "technologies-with-error-message",
   fieldset: {
     legend: {
       text: "Which technologies do you use in your role?",

--- a/src/nunjucks/moduk/components/checkboxes/__examples__/with-item-hint.njk
+++ b/src/nunjucks/moduk/components/checkboxes/__examples__/with-item-hint.njk
@@ -1,7 +1,7 @@
 {% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes %}
 
 {{ modukCheckboxes({
-  name: "technologies",
+  name: "technologies-with-item-hint",
   fieldset: {
     legend: {
       text: "Which technologies do you use in your role?",

--- a/src/nunjucks/moduk/components/checkboxes/__examples__/with-none-option.njk
+++ b/src/nunjucks/moduk/components/checkboxes/__examples__/with-none-option.njk
@@ -1,7 +1,7 @@
 {% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes %}
 
 {{ modukCheckboxes({
-  name: "technologies",
+  name: "technologies-with-none-option",
   fieldset: {
     legend: {
       text: "Which technologies do you use in your role?",


### PR DESCRIPTION
This PR makes the example ids unique for use in the guidance site.