### PR TITLE
fix(styles): Correct typo in font-family

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9718,9 +9718,9 @@
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "node_modules/http-errors": {
@@ -24507,9 +24507,9 @@
       }
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "http-errors": {

--- a/src/css/_variables.scss
+++ b/src/css/_variables.scss
@@ -4,7 +4,7 @@
 $moduk-assets-path: '/assets/' !default;
 $moduk-images-path: '#{$moduk-assets-path}images/' !default;
 
-$moduk-font-family: 'Hevetica Neue', 'Arial', 'sans-serif' !default;
+$moduk-font-family: 'Helvetica Neue', 'Arial', 'sans-serif' !default;
 
 $moduk-brand-colour: colour-palette.moduk-colour('maroon') !default;
 $moduk-header-link-active: #af6098 !default;


### PR DESCRIPTION
There was a typo which meant Helvetica Neue wasn't used when it was available.