### PR TITLE
release!: Mark next release as version 1.0.0

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,7 +2,7 @@ module.exports = {
   extends: ['@commitlint/config-conventional'],
   parserPreset: {
     parserOpts: {
-      headerPattern: /^([^():]*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$/,
+      headerPattern: /^([^!():]*)(?:\((.*)\))?!?: (.*)$/,
     },
   },
   rules: {


### PR DESCRIPTION
This required an update to the commitlint config to add support for using exclamation mark to flag breaking changes.