### PR TITLE
fix(macros): Reduce whitespace in emitted HTML

### DIFF
--- a/src/nunjucks/moduk/components/accordion/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/accordion/__examples__/default.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/accordion/macro.njk" import modukAccordion %}
+{% from "moduk/components/accordion/macro.njk" import modukAccordion -%}
 
 {{ modukAccordion({
   id: "accordion-default",
@@ -36,4 +36,4 @@
       }
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/accordion/__examples__/with-summary-lines.njk
+++ b/src/nunjucks/moduk/components/accordion/__examples__/with-summary-lines.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/accordion/macro.njk" import modukAccordion %}
+{% from "moduk/components/accordion/macro.njk" import modukAccordion -%}
 
 {{ modukAccordion({
   id: "accordion-with-summary-sections",
@@ -119,4 +119,4 @@
       }
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/accordion/macro.njk
+++ b/src/nunjucks/moduk/components/accordion/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/accordion/macro.njk" import govukAccordion %}
 
-{% macro modukAccordion(params) %}
+{% macro modukAccordion(params) -%}
   {{ govukAccordion(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/back-link/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/back-link/__examples__/default.njk
@@ -1,6 +1,6 @@
-{% from "moduk/components/back-link/macro.njk" import modukBackLink %}
+{% from "moduk/components/back-link/macro.njk" import modukBackLink -%}
 
 {{ modukBackLink({
   text: "Back",
   href: "#"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/back-link/macro.njk
+++ b/src/nunjucks/moduk/components/back-link/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
-{% macro modukBackLink(params) %}
+{% macro modukBackLink(params) -%}
   {{ govukBackLink(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/breadcrumbs/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/breadcrumbs/__examples__/default.njk
@@ -1,4 +1,4 @@
-{%- from "moduk/components/breadcrumbs/macro.njk" import modukBreadcrumbs -%}
+{% from "moduk/components/breadcrumbs/macro.njk" import modukBreadcrumbs -%}
 
 {{ modukBreadcrumbs({
   items: [
@@ -15,4 +15,4 @@
       href: "#"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/breadcrumbs/macro.njk
+++ b/src/nunjucks/moduk/components/breadcrumbs/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
-{% macro modukBreadcrumbs(params) %}
+{%- macro modukBreadcrumbs(params) -%}
   {{ govukBreadcrumbs(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/button/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/button/__examples__/default.njk
@@ -1,5 +1,5 @@
-{% from "moduk/components/button/macro.njk" import modukButton %}
+{% from "moduk/components/button/macro.njk" import modukButton -%}
 
 {{ modukButton({
   text: "Save and continue"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/button/__examples__/disabled.njk
+++ b/src/nunjucks/moduk/components/button/__examples__/disabled.njk
@@ -1,6 +1,6 @@
-{% from "moduk/components/button/macro.njk" import modukButton %}
+{% from "moduk/components/button/macro.njk" import modukButton -%}
 
 {{ modukButton({
   text: "Disabled button",
   disabled: true
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/button/__examples__/group-link.njk
+++ b/src/nunjucks/moduk/components/button/__examples__/group-link.njk
@@ -1,9 +1,9 @@
-{% from "moduk/components/button/macro.njk" import modukButton %}
+{% from "moduk/components/button/macro.njk" import modukButton -%}
 
 <div class="govuk-button-group">
   {{ modukButton({
     text: "Continue"
-  }) }}
+  }) -}}
 
   <a class="govuk-link" href="#">Cancel</a>
 </div>

--- a/src/nunjucks/moduk/components/button/__examples__/grouping.njk
+++ b/src/nunjucks/moduk/components/button/__examples__/grouping.njk
@@ -1,12 +1,12 @@
-{% from "moduk/components/button/macro.njk" import modukButton %}
+{% from "moduk/components/button/macro.njk" import modukButton -%}
 
 <div class="govuk-button-group">
   {{ modukButton({
     text: "Save and continue"
-  }) }}
+  }) -}}
 
-  {{ modukButton({
+  {{- modukButton({
     text: "Save as draft",
     classes: "govuk-button--secondary"
-  }) }}
+  }) -}}
 </div>

--- a/src/nunjucks/moduk/components/button/__examples__/prevent-double-click.njk
+++ b/src/nunjucks/moduk/components/button/__examples__/prevent-double-click.njk
@@ -1,5 +1,4 @@
-{% from "moduk/components/button/macro.njk" import modukButton %}
-
+{% from "moduk/components/button/macro.njk" import modukButton -%}
 
 <form id="testForm">
   {{ modukButton({

--- a/src/nunjucks/moduk/components/button/__examples__/secondary.njk
+++ b/src/nunjucks/moduk/components/button/__examples__/secondary.njk
@@ -1,6 +1,6 @@
-{% from "moduk/components/button/macro.njk" import modukButton %}
+{% from "moduk/components/button/macro.njk" import modukButton -%}
 
 {{ modukButton({
   text: "Find address",
   classes: "govuk-button--secondary"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/button/__examples__/start.njk
+++ b/src/nunjucks/moduk/components/button/__examples__/start.njk
@@ -1,7 +1,7 @@
-{% from "moduk/components/button/macro.njk" import modukButton %}
+{% from "moduk/components/button/macro.njk" import modukButton -%}
 
 {{ modukButton({
   text: "Start now",
   href: "#",
   isStartButton: true
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/button/__examples__/warning.njk
+++ b/src/nunjucks/moduk/components/button/__examples__/warning.njk
@@ -1,6 +1,6 @@
-{% from "moduk/components/button/macro.njk" import modukButton %}
+{% from "moduk/components/button/macro.njk" import modukButton -%}
 
 {{ modukButton({
   text: "Delete account",
   classes: "govuk-button--warning"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/button/macro.njk
+++ b/src/nunjucks/moduk/components/button/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% macro modukButton(params) %}
+{% macro modukButton(params) -%}
   {{ govukButton(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/character-count/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/character-count/__examples__/default.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/character-count/macro.njk" import modukCharacterCount %}
+{% from "moduk/components/character-count/macro.njk" import modukCharacterCount -%}
 
 {{ modukCharacterCount({
   name: "with-hint",
@@ -12,4 +12,4 @@
   hint: {
     text: "This will be shown on the public page for the event, below the event title"
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/character-count/__examples__/not-as-page-heading.njk
+++ b/src/nunjucks/moduk/components/character-count/__examples__/not-as-page-heading.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/character-count/macro.njk" import modukCharacterCount %}
+{% from "moduk/components/character-count/macro.njk" import modukCharacterCount -%}
 
 {{ modukCharacterCount({
   name: "not-as-page-heading",
@@ -7,4 +7,4 @@
   label: {
     text: "Describe the nature of your event"
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/character-count/__examples__/with-error-message.njk
+++ b/src/nunjucks/moduk/components/character-count/__examples__/with-error-message.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/character-count/macro.njk" import modukCharacterCount %}
+{% from "moduk/components/character-count/macro.njk" import modukCharacterCount -%}
 
 {{ modukCharacterCount({
   id: "exceeding-characters",
@@ -13,4 +13,4 @@
   errorMessage: {
     text: "Job description must be 350 characters or less"
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/character-count/__examples__/with-threshold.njk
+++ b/src/nunjucks/moduk/components/character-count/__examples__/with-threshold.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/character-count/macro.njk" import modukCharacterCount %}
+{% from "moduk/components/character-count/macro.njk" import modukCharacterCount -%}
 
 {{ modukCharacterCount({
   name: "threshold",
@@ -11,4 +11,4 @@
     classes: "govuk-label--l",
     isPageHeading: true
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/character-count/__examples__/word-count.njk
+++ b/src/nunjucks/moduk/components/character-count/__examples__/word-count.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/character-count/macro.njk" import modukCharacterCount %}
+{% from "moduk/components/character-count/macro.njk" import modukCharacterCount -%}
 
 {{ modukCharacterCount({
   name: "word-count",
@@ -9,4 +9,4 @@
     classes: "govuk-label--l",
     isPageHeading: true
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/character-count/macro.njk
+++ b/src/nunjucks/moduk/components/character-count/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 
-{% macro modukCharacterCount(params) %}
+{% macro modukCharacterCount(params) -%}
   {{ govukCharacterCount(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/checkboxes/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/checkboxes/__examples__/default.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes %}
+{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes -%}
 
 {{ modukCheckboxes({
   name: "technologies-default",
@@ -34,4 +34,4 @@
       text: "Another technology"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/checkboxes/__examples__/not-as-page-heading.njk
+++ b/src/nunjucks/moduk/components/checkboxes/__examples__/not-as-page-heading.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes %}
+{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes -%}
 
 {{ modukCheckboxes({
   name: "technologies-not-as-page-heading",
@@ -32,4 +32,4 @@
       text: "Another technology"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/checkboxes/__examples__/small.njk
+++ b/src/nunjucks/moduk/components/checkboxes/__examples__/small.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes %}
+{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes -%}
 
 {{ modukCheckboxes({
   name: "organisation-small",
@@ -28,4 +28,4 @@
       text: "Strategic Command"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/checkboxes/__examples__/with-conditional-reveal.njk
+++ b/src/nunjucks/moduk/components/checkboxes/__examples__/with-conditional-reveal.njk
@@ -1,8 +1,8 @@
-{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes %}
-{% from "moduk/components/input/macro.njk" import modukInput %}
+{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes -%}
+{% from "moduk/components/input/macro.njk" import modukInput -%}
 
 {% set emailHtml %}
-{{ modukInput({
+{{- modukInput({
   id: "contact-by-email",
   name: "contact-by-email",
   type: "email",
@@ -12,11 +12,11 @@
   label: {
     text: "Email address"
   }
-}) }}
+}) -}}
 {% endset -%}
 
 {% set phoneHtml %}
-{{ modukInput({
+{{- modukInput({
   id: "contact-by-phone",
   name: "contact-by-phone",
   type: "tel",
@@ -25,11 +25,11 @@
   label: {
     text: "Phone number"
   }
-}) }}
+}) -}}
 {% endset -%}
 
 {% set textHtml %}
-{{ modukInput({
+{{- modukInput({
   id: "contact-by-text",
   name: "contact-by-text",
   type: "tel",
@@ -38,7 +38,7 @@
   label: {
     text: "Mobile phone number"
   }
-}) }}
+}) -}}
 {% endset -%}
 
 {{ modukCheckboxes({
@@ -77,4 +77,4 @@
       }
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/checkboxes/__examples__/with-error-message.njk
+++ b/src/nunjucks/moduk/components/checkboxes/__examples__/with-error-message.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes %}
+{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes -%}
 
 {{ modukCheckboxes({
   name: "technologies-with-error-message",
@@ -37,4 +37,4 @@
       text: "Another technology"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/checkboxes/__examples__/with-item-hint.njk
+++ b/src/nunjucks/moduk/components/checkboxes/__examples__/with-item-hint.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes %}
+{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes -%}
 
 {{ modukCheckboxes({
   name: "technologies-with-item-hint",
@@ -37,4 +37,4 @@
       text: "Another technology"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/checkboxes/__examples__/with-none-option.njk
+++ b/src/nunjucks/moduk/components/checkboxes/__examples__/with-none-option.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes %}
+{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes -%}
 
 {{ modukCheckboxes({
   name: "technologies-with-none-option",
@@ -38,4 +38,4 @@
       behaviour: "exclusive"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/checkboxes/macro.njk
+++ b/src/nunjucks/moduk/components/checkboxes/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
-{% macro modukCheckboxes(params) %}
+{% macro modukCheckboxes(params) -%}
   {{ govukCheckboxes(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/cookie-banner/__examples__/accepted.njk
+++ b/src/nunjucks/moduk/components/cookie-banner/__examples__/accepted.njk
@@ -3,11 +3,11 @@
 {% set html %}
   <p class="govuk-body">We use some essential cookies to make this service work.</p>
   <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
-{% endset %}
+{% endset -%}
 
-{% set acceptHtml %}
+{%- set acceptHtml %}
   <p class="govuk-body">You’ve accepted analytics cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
-{% endset %}
+{% endset -%}
 
 {{ modukCookieBanner({
   ariaLabel: "Cookies on the Defence Service Manual",
@@ -44,4 +44,4 @@
       ]
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/cookie-banner/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/cookie-banner/__examples__/default.njk
@@ -3,7 +3,7 @@
 {% set html %}
   <p class="govuk-body">We use some essential cookies to make this service work.</p>
   <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
-{% endset %}
+{% endset -%}
 
 {{ modukCookieBanner({
   ariaLabel: "Cookies on the Defence Service Manual",
@@ -31,4 +31,4 @@
       ]
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/cookie-banner/__examples__/rejected.njk
+++ b/src/nunjucks/moduk/components/cookie-banner/__examples__/rejected.njk
@@ -1,14 +1,13 @@
 {%- from "moduk/components/cookie-banner/macro.njk" import modukCookieBanner -%}
 
-{% set html %}
+{%- set html %}
   <p class="govuk-body">We use some essential cookies to make this service work.</p>
   <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
-{% endset %}
+{% endset -%}
 
 {% set rejectHtml %}
    <p class="govuk-body">You’ve rejected analytics cookies. You can <a class="govuk-link" href="#">change your cookie settings</a> at any time.</p>
-{% endset %}
-
+{% endset -%}
 
 {{ modukCookieBanner({
   ariaLabel: "Cookies on the Defence Service Manual",
@@ -45,4 +44,4 @@
       ]
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/cookie-banner/macro.njk
+++ b/src/nunjucks/moduk/components/cookie-banner/macro.njk
@@ -1,5 +1,5 @@
-{% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
+{%- from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
-{% macro modukCookieBanner(params) %}
+{%- macro modukCookieBanner(params) -%}
   {{ govukCookieBanner(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/date-input/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/date-input/__examples__/default.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/date-input/macro.njk" import modukDateInput %}
+{% from "moduk/components/date-input/macro.njk" import modukDateInput -%}
 
 {{ modukDateInput({
   id: "contract-start-date-default",
@@ -13,4 +13,4 @@
   hint: {
     text: "For example, 27 3 2023"
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/date-input/__examples__/not-as-page-heading.njk
+++ b/src/nunjucks/moduk/components/date-input/__examples__/not-as-page-heading.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/date-input/macro.njk" import modukDateInput %}
+{% from "moduk/components/date-input/macro.njk" import modukDateInput -%}
 
 {{ modukDateInput({
   id: "contract-start-date-not-as-heading",
@@ -11,4 +11,4 @@
   hint: {
     text: "For example, 27 3 2023"
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/date-input/__examples__/with-date-part-error.njk
+++ b/src/nunjucks/moduk/components/date-input/__examples__/with-date-part-error.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/date-input/macro.njk" import modukDateInput %}
+{% from "moduk/components/date-input/macro.njk" import modukDateInput -%}
 
 {{ modukDateInput({
   id: "contract-start-date-with-part-error",
@@ -32,4 +32,4 @@
          name: "year"
        }
      ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/date-input/__examples__/with-whole-date-error.njk
+++ b/src/nunjucks/moduk/components/date-input/__examples__/with-whole-date-error.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/date-input/macro.njk" import modukDateInput %}
+{% from "moduk/components/date-input/macro.njk" import modukDateInput -%}
 
 {{ modukDateInput({
   id: "contract-start-date-with-whole-error",
@@ -33,4 +33,4 @@
       value: "2001"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/date-input/macro.njk
+++ b/src/nunjucks/moduk/components/date-input/macro.njk
@@ -1,5 +1,5 @@
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput -%}
 
-{% macro modukDateInput(params) %}
+{% macro modukDateInput(params) -%}
   {{ govukDateInput(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/details/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/details/__examples__/default.njk
@@ -1,6 +1,6 @@
-{% from "moduk/components/details/macro.njk" import modukDetails %}
+{% from "moduk/components/details/macro.njk" import modukDetails -%}
 
 {{ modukDetails({
   summaryText: "Help with organisation",
   text: "We need to know the organisation you work for so we can forward your request to the correct team."
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/details/__examples__/open.njk
+++ b/src/nunjucks/moduk/components/details/__examples__/open.njk
@@ -1,7 +1,7 @@
-{% from "moduk/components/details/macro.njk" import modukDetails %}
+{% from "moduk/components/details/macro.njk" import modukDetails -%}
 
 {{ modukDetails({
   summaryText: "Help with organisation",
   text: "We need to know the organisation you work for so we can forward your request to the correct team.",
   open: true
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/error-message/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/error-message/__examples__/default.njk
@@ -1,5 +1,5 @@
-{% from "moduk/components/error-message/macro.njk" import modukErrorMessage %}
+{% from "moduk/components/error-message/macro.njk" import modukErrorMessage -%}
 
 {{ modukErrorMessage({
   text: "Enter a first name"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/error-message/macro.njk
+++ b/src/nunjucks/moduk/components/error-message/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
 
-{% macro modukErrorMessage(params) %}
+{% macro modukErrorMessage(params) -%}
   {{ govukErrorMessage(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/error-summary/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/error-summary/__examples__/default.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/error-summary/macro.njk" import modukErrorSummary %}
+{% from "moduk/components/error-summary/macro.njk" import modukErrorSummary -%}
 
 {{ modukErrorSummary({
   titleText: "There is a problem",
@@ -13,4 +13,4 @@
       href: "#full-name-input"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/error-summary/__examples__/with-error-linked-to-checkbox.njk
+++ b/src/nunjucks/moduk/components/error-summary/__examples__/with-error-linked-to-checkbox.njk
@@ -1,5 +1,5 @@
-{% from "moduk/components/error-summary/macro.njk" import modukErrorSummary %}
-{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes %}
+{% from "moduk/components/error-summary/macro.njk" import modukErrorSummary -%}
+{% from "moduk/components/checkboxes/macro.njk" import modukCheckboxes -%}
 
 <div>
   {{ modukErrorSummary({
@@ -10,7 +10,7 @@
         href: "#technologies"
       }
     ]
-  }) }}
+  }) -}}
 
 {{ modukCheckboxes({
   name: "technologies",
@@ -49,6 +49,6 @@
       text: "Another technology"
     }
   ]
-}) }}
+}) -}}
 
 </div>

--- a/src/nunjucks/moduk/components/error-summary/__examples__/with-error-linked-to-date-part.njk
+++ b/src/nunjucks/moduk/components/error-summary/__examples__/with-error-linked-to-date-part.njk
@@ -1,5 +1,5 @@
-{% from "moduk/components/error-summary/macro.njk" import modukErrorSummary %}
-{% from "moduk/components/date-input/macro.njk" import modukDateInput %}
+{% from "moduk/components/error-summary/macro.njk" import modukErrorSummary -%}
+{% from "moduk/components/date-input/macro.njk" import modukDateInput -%}
 
 <div>
   {{ modukErrorSummary({
@@ -10,7 +10,7 @@
         href: "#incorect-date-format-year"
       }
     ]
-  }) }}
+  }) -}}
 
   {{ modukDateInput({
     id: "incorect-date-format",

--- a/src/nunjucks/moduk/components/error-summary/macro.njk
+++ b/src/nunjucks/moduk/components/error-summary/macro.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% macro modukErrorSummary(params) %}
+{% macro modukErrorSummary(params) -%}
   {% if caller -%}
     {% call govukErrorSummary(params) -%}
       {{ caller() }}
@@ -8,4 +8,4 @@
   {%- else -%}
     {{ govukErrorSummary(params) }}
   {%- endif %}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/fieldset/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/fieldset/__examples__/default.njk
@@ -1,5 +1,5 @@
-{% from "moduk/components/input/macro.njk" import modukInput %}
-{% from "moduk/components/fieldset/macro.njk" import modukFieldset %}
+{% from "moduk/components/input/macro.njk" import modukInput -%}
+{% from "moduk/components/fieldset/macro.njk" import modukFieldset -%}
 
 {% call modukFieldset({
   legend: {
@@ -7,7 +7,7 @@
     classes: "govuk-fieldset__legend--l",
     isPageHeading: true
   }
-}) %}
+}) -%}
   {{ modukInput({
     label: {
       text: 'Address line 1'
@@ -15,7 +15,7 @@
     id: "address-line-1",
     name: "address-line-1",
     autocomplete: "address-line1"
-  }) }}
+  }) -}}
   {{ modukInput({
     label: {
       text: 'Address line 2 (optional)'
@@ -23,7 +23,7 @@
     id: "address-line-2",
     name: "address-line-2",
     autocomplete: "address-line2"
-  }) }}
+  }) -}}
   {{ modukInput({
     label: {
       text: "Town or city"
@@ -32,7 +32,7 @@
     id: "address-town",
     name: "address-town",
     autocomplete: "address-level2"
-  }) }}
+  }) -}}
   {{ modukInput({
     label: {
       text: "Postcode"
@@ -41,5 +41,5 @@
     id: "address-postcode",
     name: "address-postcode",
     autocomplete: "postal-code"
-  }) }}
-{% endcall %}
+  }) -}}
+{% endcall -%}

--- a/src/nunjucks/moduk/components/file-upload/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/file-upload/__examples__/default.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/file-upload/macro.njk" import modukFileUpload %}
+{% from "moduk/components/file-upload/macro.njk" import modukFileUpload -%}
 
 {{ modukFileUpload({
   id: "file-upload-1",
@@ -6,4 +6,4 @@
   label: {
     text: "Upload a file"
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/file-upload/__examples__/with-error.njk
+++ b/src/nunjucks/moduk/components/file-upload/__examples__/with-error.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/file-upload/macro.njk" import modukFileUpload %}
+{% from "moduk/components/file-upload/macro.njk" import modukFileUpload -%}
 
 {{ modukFileUpload({
   id: "file-upload-with-error",
@@ -9,4 +9,4 @@
   errorMessage: {
     text: "The CSV must be smaller than 2MB"
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/file-upload/macro.njk
+++ b/src/nunjucks/moduk/components/file-upload/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
-{% macro modukFileUpload(params) %}
+{% macro modukFileUpload(params) -%}
   {{ govukFileUpload(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/footer/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/footer/__examples__/default.njk
@@ -1,3 +1,3 @@
-{%- from "moduk/components/footer/macro.njk" import modukFooter -%}
+{% from "moduk/components/footer/macro.njk" import modukFooter -%}
 
-{{ modukFooter({}) }}
+{{ modukFooter({}) -}}

--- a/src/nunjucks/moduk/components/footer/__examples__/with-links.njk
+++ b/src/nunjucks/moduk/components/footer/__examples__/with-links.njk
@@ -1,4 +1,4 @@
-{%- from "moduk/components/footer/macro.njk" import modukFooter -%}
+{% from "moduk/components/footer/macro.njk" import modukFooter -%}
 
 {{ modukFooter({
   meta: {
@@ -17,4 +17,4 @@
       }
     ]
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/footer/__examples__/with-secondary-navigation-and-links.njk
+++ b/src/nunjucks/moduk/components/footer/__examples__/with-secondary-navigation-and-links.njk
@@ -1,4 +1,4 @@
-{%- from "moduk/components/footer/macro.njk" import modukFooter -%}
+{% from "moduk/components/footer/macro.njk" import modukFooter -%}
 
 {{ modukFooter({
   navigation: [
@@ -69,4 +69,4 @@
     ],
     html: 'Built by <a href="#" class="govuk-footer__link">Defence Digital</a>'
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/footer/__examples__/with-secondary-navigation.njk
+++ b/src/nunjucks/moduk/components/footer/__examples__/with-secondary-navigation.njk
@@ -1,4 +1,4 @@
-{%- from "moduk/components/footer/macro.njk" import modukFooter -%}
+{% from "moduk/components/footer/macro.njk" import modukFooter -%}
 
 {{ modukFooter({
   navigation: [
@@ -52,4 +52,4 @@
       ]
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/footer/macro.njk
+++ b/src/nunjucks/moduk/components/footer/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/footer/macro.njk" import govukFooter %}
 
-{% macro modukFooter(params) %}
+{% macro modukFooter(params) -%}
   {{ govukFooter(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/header/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/header/__examples__/default.njk
@@ -1,3 +1,3 @@
-{%- from "moduk/components/header/macro.njk" import modukHeader -%}
+{% from "moduk/components/header/macro.njk" import modukHeader -%}
 
-{{ modukHeader({}) }}
+{{ modukHeader({}) -}}

--- a/src/nunjucks/moduk/components/header/__examples__/with-service-name-and-navigation.njk
+++ b/src/nunjucks/moduk/components/header/__examples__/with-service-name-and-navigation.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/header/macro.njk" import modukHeader %}
+{% from "moduk/components/header/macro.njk" import modukHeader -%}
 
 {{ modukHeader({
   homepageUrl: "#",
@@ -23,4 +23,4 @@
       text: "Navigation item 4"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/header/__examples__/with-service-name-and-no-service-url.njk
+++ b/src/nunjucks/moduk/components/header/__examples__/with-service-name-and-no-service-url.njk
@@ -1,6 +1,6 @@
-{% from "moduk/components/header/macro.njk" import modukHeader %}
+{% from "moduk/components/header/macro.njk" import modukHeader -%}
 
 {{ modukHeader({
   homepageUrl: "#",
   serviceName: "Service name"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/header/__examples__/with-service-name.njk
+++ b/src/nunjucks/moduk/components/header/__examples__/with-service-name.njk
@@ -1,7 +1,7 @@
-{% from "moduk/components/header/macro.njk" import modukHeader %}
+{%- from "moduk/components/header/macro.njk" import modukHeader -%}
 
 {{ modukHeader({
   homepageUrl: "#",
   serviceName: "Service name",
   serviceUrl: "#"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/header/macro.njk
+++ b/src/nunjucks/moduk/components/header/macro.njk
@@ -5,9 +5,9 @@
  The logo has been changed, some CSS classes have been added and there are some slight markup changes.
 #}
 
-{% macro modukHeader(params) %}
+{% macro modukHeader(params) -%}
 
-{% set menuButtonText = params.menuButtonText if params.menuButtonText else 'Menu' %}
+{% set menuButtonText = params.menuButtonText if params.menuButtonText else 'Menu' -%}
 
 <header class="govuk-header {{ params.classes if params.classes }}" role="banner" data-module="govuk-header"
         {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
@@ -35,43 +35,42 @@
         </span>
       </a>
     </div>
-    {% if params.serviceName or params.navigation  %}
+    {%- if params.serviceName or params.navigation %}
     <div class="govuk-header__content">
-    {% if params.serviceName %}
-    {% if params.serviceUrl %}
+    {%- if params.serviceName %}
+    {%- if params.serviceUrl %}
       <a href="{{ params.serviceUrl }}" class="govuk-header__link moduk-header__service-name govuk-header__service-name">
         {{ params.serviceName }}
       </a>
-    {% else%}
+    {%- else %}
       <span class="moduk-header__service-name govuk-header__service-name">
         {{ params.serviceName }}
       </span>
-    {% endif %}
-    {% endif %}
-    {% if params.navigation %}
-    <nav aria-label="{{ params.navigationLabel | default(menuButtonText) }}" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}">
-      <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="{{ params.menuButtonLabel | default('Show or hide menu') }}" hidden>{{ menuButtonText }}</button>
-
-      <ul id="navigation" class="govuk-header__navigation-list">
-        {% for item in params.navigation %}
-          {% if item.text or item.html %}
-            <li class="govuk-header__navigation-item{{ ' govuk-header__navigation-item--active moduk-header__navigation-item--active' if item.active }}">
-              {% if item.href %}
-                <a class="govuk-header__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-              {% endif %}
-                {{ item.html | safe if item.html else item.text }}
-              {% if item.href %}
-                </a>
-              {% endif %}
-            </li>
-          {% endif %}
-        {% endfor %}
-      </ul>
-    </nav>
-    {% endif %}
+    {% endif -%}
+    {%- endif -%}
+    {%- if params.navigation %}
+      <nav aria-label="{{ params.navigationLabel | default(menuButtonText) }}" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}">
+        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="{{ params.menuButtonLabel | default('Show or hide menu') }}" hidden>{{ menuButtonText }}</button>
+        <ul id="navigation" class="govuk-header__navigation-list">
+        {%- for item in params.navigation -%}
+        {%- if item.text or item.html %}
+          <li class="govuk-header__navigation-item{{ ' govuk-header__navigation-item--active moduk-header__navigation-item--active' if item.active }}">
+            {% if item.href -%}
+              <a class="govuk-header__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+            {%- endif -%}
+              {{ item.html | safe if item.html else item.text }}
+            {%- if item.href -%}
+              </a>
+            {%- endif %}
+          </li>
+        {%- endif %}
+        {%- endfor %}
+        </ul>
+      </nav>
+    {%- endif %}
     </div>
-    {% endif %}
+    {%- endif %}
   </div>
 </header>
 
-{% endmacro %}
+{%- endmacro -%}

--- a/src/nunjucks/moduk/components/input/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/input/__examples__/default.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/input/macro.njk" import modukInput %}
+{% from "moduk/components/input/macro.njk" import modukInput -%}
 
 {{ modukInput({
   label: {
@@ -8,4 +8,4 @@
   },
   id: "default",
   name: "event-name-default"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/input/__examples__/not-as-page-heading.njk
+++ b/src/nunjucks/moduk/components/input/__examples__/not-as-page-heading.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/input/macro.njk" import modukInput %}
+{% from "moduk/components/input/macro.njk" import modukInput  -%}
 
 {{ modukInput({
   label: {
@@ -6,4 +6,4 @@
   },
   id: "with-not-as-page-heading",
   name: "event-name-with-not-as-page-heading"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/input/__examples__/with-error.njk
+++ b/src/nunjucks/moduk/components/input/__examples__/with-error.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/input/macro.njk" import modukInput %}
+{% from "moduk/components/input/macro.njk" import modukInput  -%}
 
 {{ modukInput({
   label: {
@@ -14,4 +14,4 @@
   errorMessage: {
     text: "Enter an event name"
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/input/__examples__/with-fixed-width.njk
+++ b/src/nunjucks/moduk/components/input/__examples__/with-fixed-width.njk
@@ -1,14 +1,14 @@
-{% from "moduk/components/input/macro.njk" import modukInput %}
+{% from "moduk/components/input/macro.njk" import modukInput  -%}
 
 <div>
-  {{ modukInput({
+  {{- modukInput({
     label: {
       text: "20 character width"
     },
     classes: "govuk-input--width-20",
     id: "width-20",
     name: "width-20"
-  }) }}
+  }) -}}
 
   {{ modukInput({
     label: {
@@ -17,7 +17,7 @@
     classes: "govuk-input--width-10",
     id: "width-10",
     name: "width-10"
-  }) }}
+  }) -}}
 
   {{ modukInput({
     label: {
@@ -26,7 +26,7 @@
     classes: "govuk-input--width-5",
     id: "width-5",
     name: "width-5"
-  }) }}
+  }) -}}
 
   {{ modukInput({
     label: {
@@ -35,7 +35,7 @@
     classes: "govuk-input--width-4",
     id: "width-4",
     name: "width-4"
-  }) }}
+  }) -}}
 
   {{ modukInput({
     label: {
@@ -44,14 +44,14 @@
     classes: "govuk-input--width-3",
     id: "width-3",
     name: "width-3"
-  }) }}
+  }) -}}
 
-    {{ modukInput({
-      label: {
-        text: "2 character width"
-      },
-      classes: "govuk-input--width-2",
-      id: "width-2",
-      name: "width-2"
-    }) }}
+  {{ modukInput({
+    label: {
+      text: "2 character width"
+    },
+    classes: "govuk-input--width-2",
+    id: "width-2",
+    name: "width-2"
+  }) -}}
 </div>

--- a/src/nunjucks/moduk/components/input/__examples__/with-fluid-width.njk
+++ b/src/nunjucks/moduk/components/input/__examples__/with-fluid-width.njk
@@ -1,14 +1,14 @@
-{% from "moduk/components/input/macro.njk" import modukInput %}
+{% from "moduk/components/input/macro.njk" import modukInput  -%}
 
 <div>
-  {{ modukInput({
+  {{- modukInput({
     label: {
       text: "Full width"
     },
     classes: "govuk-!-width-full",
     id: "full",
     name: "full"
-  }) }}
+  }) -}}
 
   {{ modukInput({
     label: {
@@ -17,7 +17,7 @@
     classes: "govuk-!-width-three-quarters",
     id: "three-quarters",
     name: "three-quarters"
-  }) }}
+  }) -}}
 
   {{ modukInput({
     label: {
@@ -26,7 +26,7 @@
     classes: "govuk-!-width-two-thirds",
     id: "two-thirds",
     name: "two-thirds"
-  }) }}
+  }) -}}
 
   {{ modukInput({
     label: {
@@ -35,7 +35,7 @@
     classes: "govuk-!-width-one-half",
     id: "one-half",
     name: "one-half"
-  }) }}
+  }) -}}
 
   {{ modukInput({
     label: {
@@ -44,7 +44,7 @@
     classes: "govuk-!-width-one-third",
     id: "one-third",
     name: "one-third"
-  }) }}
+  }) -}}
 
   {{ modukInput({
     label: {
@@ -53,5 +53,5 @@
     classes: "govuk-!-width-one-quarter",
     id: "one-quarter",
     name: "one-quarter"
-  }) }}
+  }) -}}
 </div>

--- a/src/nunjucks/moduk/components/input/__examples__/with-hint.njk
+++ b/src/nunjucks/moduk/components/input/__examples__/with-hint.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/input/macro.njk" import modukInput %}
+{% from "moduk/components/input/macro.njk" import modukInput  -%}
 
 {{ modukInput({
   label: {
@@ -11,4 +11,4 @@
   },
   id: "with-hint",
   name: "event-name-with-hint"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/input/__examples__/with-numeric.njk
+++ b/src/nunjucks/moduk/components/input/__examples__/with-numeric.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/input/macro.njk" import modukInput %}
+{% from "moduk/components/input/macro.njk" import modukInput  -%}
 
 {{ modukInput({
   label: {
@@ -14,4 +14,4 @@
   name: "account-number-with-numeric",
   inputmode: "numeric",
   spellcheck: false
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/input/__examples__/with-prefix-and-suffix-error.njk
+++ b/src/nunjucks/moduk/components/input/__examples__/with-prefix-and-suffix-error.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/input/macro.njk" import modukInput %}
+{% from "moduk/components/input/macro.njk" import modukInput  -%}
 
 {{ modukInput({
   id: "with-prefix-and-suffix-error",
@@ -19,4 +19,4 @@
   },
   classes: "govuk-input--width-5",
   spellcheck: false
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/input/__examples__/with-prefix-and-suffix.njk
+++ b/src/nunjucks/moduk/components/input/__examples__/with-prefix-and-suffix.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/input/macro.njk" import modukInput %}
+{% from "moduk/components/input/macro.njk" import modukInput  -%}
 
 {{ modukInput({
   id: "with-prefix-and-suffix",
@@ -16,4 +16,4 @@
   },
   classes: "govuk-input--width-5",
   spellcheck: false
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/input/__examples__/with-prefix.njk
+++ b/src/nunjucks/moduk/components/input/__examples__/with-prefix.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/input/macro.njk" import modukInput %}
+{% from "moduk/components/input/macro.njk" import modukInput  -%}
 
 {{ modukInput({
   id: "with-prefix",
@@ -13,4 +13,4 @@
   },
   classes: "govuk-input--width-5",
   spellcheck: false
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/input/__examples__/with-suffix.njk
+++ b/src/nunjucks/moduk/components/input/__examples__/with-suffix.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/input/macro.njk" import modukInput %}
+{% from "moduk/components/input/macro.njk" import modukInput  -%}
 
 {{ modukInput({
   id: "with-suffix",
@@ -13,4 +13,4 @@
   },
   classes: "govuk-input--width-5",
   spellcheck: false
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/input/macro.njk
+++ b/src/nunjucks/moduk/components/input/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% macro modukInput(params) %}
+{% macro modukInput(params) -%}
   {{ govukInput(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/inset-text/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/inset-text/__examples__/default.njk
@@ -1,5 +1,5 @@
-{%- from "moduk/components/inset-text/macro.njk" import modukInsetText -%}
+{% from "moduk/components/inset-text/macro.njk" import modukInsetText -%}
 
-{{ modukInsetText({ 
+{{ modukInsetText({
   text: "You’ll get confirmation that we have received your report within 5 working days."
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/inset-text/macro.njk
+++ b/src/nunjucks/moduk/components/inset-text/macro.njk
@@ -7,5 +7,5 @@
     {%- endcall %}
   {%- else -%}
     {{ govukInsetText(params) }}
-  {%- endif %}
+  {%- endif -%}
 {%- endmacro %}

--- a/src/nunjucks/moduk/components/notification-banner/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/notification-banner/__examples__/default.njk
@@ -1,5 +1,5 @@
-{% from "moduk/components/notification-banner/macro.njk" import modukNotificationBanner %}
+{% from "moduk/components/notification-banner/macro.njk" import modukNotificationBanner -%}
 
 {{ modukNotificationBanner({
   text: 'There may be a delay in processing your application because of the coronavirus outbreak.'
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/notification-banner/__examples__/success.njk
+++ b/src/nunjucks/moduk/components/notification-banner/__examples__/success.njk
@@ -1,13 +1,13 @@
-{% from "moduk/components/notification-banner/macro.njk" import modukNotificationBanner %}
+{% from "moduk/components/notification-banner/macro.njk" import modukNotificationBanner -%}
 
 {% set html %}
   <h3 class="govuk-notification-banner__heading">
     Training outcome recorded and trainee withdrawn
   </h3>
   <p class="govuk-body">Contact <a class="govuk-notification-banner__link" href="#">example@department.gov.uk</a> if you think there’s a problem.</p>
-{% endset %}
+{% endset -%}
 
 {{ modukNotificationBanner({
   html: html,
   type: 'success'
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/notification-banner/__examples__/with-html.njk
+++ b/src/nunjucks/moduk/components/notification-banner/__examples__/with-html.njk
@@ -1,12 +1,12 @@
-{% from "moduk/components/notification-banner/macro.njk" import modukNotificationBanner %}
+{% from "moduk/components/notification-banner/macro.njk" import modukNotificationBanner -%}
 
 {% set html %}
   <p class="govuk-notification-banner__heading">
     You have 7 days left to send your application.
     <a class="govuk-notification-banner__link" href="#">View application</a>.
   </p>
-{% endset %}
+{% endset -%}
 
 {{ modukNotificationBanner({
   html: html
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/notification-banner/macro.njk
+++ b/src/nunjucks/moduk/components/notification-banner/macro.njk
@@ -3,9 +3,9 @@
 {% macro modukNotificationBanner(params) -%}
   {% if caller -%}
     {% call govukNotificationBanner(params) -%}
-      {{ caller() }}
+      {{- caller() -}}
     {%- endcall %}
   {%- else -%}
-    {{ govukNotificationBanner(params) }}
+    {{- govukNotificationBanner(params) -}}
   {%- endif %}
 {%- endmacro %}

--- a/src/nunjucks/moduk/components/pagination/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/pagination/__examples__/default.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/pagination/macro.njk" import modukPagination %}
+{% from "moduk/components/pagination/macro.njk" import modukPagination -%}
 
 {{ modukPagination({
   previous: {
@@ -22,4 +22,4 @@
       href: "#"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/pagination/__examples__/on-the-first-page.njk
+++ b/src/nunjucks/moduk/components/pagination/__examples__/on-the-first-page.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/pagination/macro.njk" import modukPagination %}
+{% from "moduk/components/pagination/macro.njk" import modukPagination -%}
 
 {{ modukPagination({
   next: {
@@ -19,4 +19,4 @@
       href: "#"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/pagination/__examples__/on-the-last-page.njk
+++ b/src/nunjucks/moduk/components/pagination/__examples__/on-the-last-page.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/pagination/macro.njk" import modukPagination %}
+{% from "moduk/components/pagination/macro.njk" import modukPagination -%}
 
 {{ modukPagination({
   previous: {
@@ -19,4 +19,4 @@
       href: "#"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/pagination/__examples__/with-ellipses.njk
+++ b/src/nunjucks/moduk/components/pagination/__examples__/with-ellipses.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/pagination/macro.njk" import modukPagination %}
+{% from "moduk/components/pagination/macro.njk" import modukPagination -%}
 
 {{ modukPagination({
   previous: {
@@ -36,4 +36,4 @@
       href: "#"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/pagination/__examples__/with-link-labels.njk
+++ b/src/nunjucks/moduk/components/pagination/__examples__/with-link-labels.njk
@@ -1,6 +1,6 @@
-{%- from "moduk/components/pagination/macro.njk" import modukPagination -%}
+{% from "moduk/components/pagination/macro.njk" import modukPagination -%}
 
-{{- modukPagination({
+{{ modukPagination({
   previous: {
     labelText: "Understanding military personnel",
     href: "#"

--- a/src/nunjucks/moduk/components/pagination/__examples__/with-next-and-previous-only.njk
+++ b/src/nunjucks/moduk/components/pagination/__examples__/with-next-and-previous-only.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/pagination/macro.njk" import modukPagination %}
+{% from "moduk/components/pagination/macro.njk" import modukPagination -%}
 
 {{ modukPagination({
   previous: {
@@ -9,4 +9,4 @@
     labelText: "3 of 3",
     href: "#"
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/pagination/macro.njk
+++ b/src/nunjucks/moduk/components/pagination/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
-{% macro modukPagination(params) %}
-  {{ govukPagination(params) }}
-{% endmacro %}
+{% macro modukPagination(params) -%}
+  {{- govukPagination(params) -}}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/panel/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/panel/__examples__/default.njk
@@ -1,6 +1,6 @@
-{% from "moduk/components/panel/macro.njk" import modukPanel %}
+{% from "moduk/components/panel/macro.njk" import modukPanel -%}
 
 {{ modukPanel({
   titleText: "Application complete",
   html: "Your reference number<br><strong>HDJ2123F</strong>"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/phase-banner/__examples__/beta.njk
+++ b/src/nunjucks/moduk/components/phase-banner/__examples__/beta.njk
@@ -1,8 +1,8 @@
-{%- from "moduk/components/phase-banner/macro.njk" import modukPhaseBanner -%}
+{% from "moduk/components/phase-banner/macro.njk" import modukPhaseBanner -%}
 
 {{ modukPhaseBanner({
   tag: {
     text: "beta"
   },
   html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/phase-banner/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/phase-banner/__examples__/default.njk
@@ -1,4 +1,4 @@
-{%- from "moduk/components/phase-banner/macro.njk" import modukPhaseBanner -%}
+{% from "moduk/components/phase-banner/macro.njk" import modukPhaseBanner -%}
 
 {{ modukPhaseBanner({
   tag: {
@@ -9,4 +9,4 @@
     "data-testid": "phase-banner"
   },
   html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/phase-banner/__examples__/with-tag-override.njk
+++ b/src/nunjucks/moduk/components/phase-banner/__examples__/with-tag-override.njk
@@ -1,4 +1,4 @@
-{%- from "moduk/components/phase-banner/macro.njk" import modukPhaseBanner -%}
+{% from "moduk/components/phase-banner/macro.njk" import modukPhaseBanner -%}
 
 {{ modukPhaseBanner({
   tag: {
@@ -6,4 +6,4 @@
     classes: "govuk-tag--grey"
   },
   html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/phase-banner/__examples__/with-text.njk
+++ b/src/nunjucks/moduk/components/phase-banner/__examples__/with-text.njk
@@ -1,8 +1,8 @@
-{%- from "moduk/components/phase-banner/macro.njk" import modukPhaseBanner -%}
+{% from "moduk/components/phase-banner/macro.njk" import modukPhaseBanner -%}
 
 {{ modukPhaseBanner({
   tag: {
     text: "beta"
   },
   text: 'This is a new service'
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/phase-banner/macro.njk
+++ b/src/nunjucks/moduk/components/phase-banner/macro.njk
@@ -1,6 +1,5 @@
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
-{% macro modukPhaseBanner(params) %}
-  {{ govukPhaseBanner(params | addCustomMODUKClass("moduk-tag--default", { not: r/^govuk-tag--/, path: "tag.classes" })) }}
-{% endmacro %}
-
+{% macro modukPhaseBanner(params) -%}
+  {{- govukPhaseBanner(params | addCustomMODUKClass("moduk-tag--default", { not: r/^govuk-tag--/, path: "tag.classes" })) -}}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/radios/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/radios/__examples__/default.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/radios/macro.njk" import modukRadios %}
+{% from "moduk/components/radios/macro.njk" import modukRadios -%}
 
 {{ modukRadios({
   name: "organisation-default",
@@ -27,4 +27,4 @@
       text: "Strategic Command"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/radios/__examples__/inline.njk
+++ b/src/nunjucks/moduk/components/radios/__examples__/inline.njk
@@ -1,4 +1,4 @@
-{%- from "moduk/components/radios/macro.njk" import modukRadios -%}
+{% from "moduk/components/radios/macro.njk" import modukRadios -%}
 
 {{ modukRadios({
   classes: "govuk-radios--inline",
@@ -23,4 +23,4 @@
       text: "No"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/radios/__examples__/not-as-page-heading.njk
+++ b/src/nunjucks/moduk/components/radios/__examples__/not-as-page-heading.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/radios/macro.njk" import modukRadios %}
+{% from "moduk/components/radios/macro.njk" import modukRadios -%}
 
 {{ modukRadios({
   name: "organisation-not-as-page-heading",
@@ -25,5 +25,5 @@
       text: "Strategic Command"
     }
   ]
-}) }}
+}) -}}
 

--- a/src/nunjucks/moduk/components/radios/__examples__/small.njk
+++ b/src/nunjucks/moduk/components/radios/__examples__/small.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/radios/macro.njk" import modukRadios %}
+{% from "moduk/components/radios/macro.njk" import modukRadios -%}
 
 {{ modukRadios({
   name: "organisation-small",
@@ -28,4 +28,4 @@
       text: "Strategic Command"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/radios/__examples__/with-conditional-reveal.njk
+++ b/src/nunjucks/moduk/components/radios/__examples__/with-conditional-reveal.njk
@@ -1,8 +1,8 @@
-{% from "moduk/components/radios/macro.njk" import modukRadios %}
-{% from "moduk/components/input/macro.njk" import modukInput %}
+{% from "moduk/components/radios/macro.njk" import modukRadios -%}
+{% from "moduk/components/input/macro.njk" import modukInput -%}
 
 {% set emailHtml %}
-{{ modukInput({
+{{- modukInput({
   id: "contact-by-email",
   name: "contact-by-email",
   type: "email",
@@ -12,11 +12,11 @@
   label: {
     text: "Email address"
   }
-}) }}
+}) -}}
 {% endset -%}
 
 {% set phoneHtml %}
-{{ modukInput({
+{{- modukInput({
   id: "contact-by-phone",
   name: "contact-by-phone",
   type: "tel",
@@ -25,11 +25,11 @@
   label: {
     text: "Phone number"
   }
-}) }}
+}) -}}
 {% endset -%}
 
 {% set textHtml %}
-{{ modukInput({
+{{- modukInput({
   id: "contact-by-text",
   name: "contact-by-text",
   type: "tel",
@@ -38,7 +38,7 @@
   label: {
     text: "Mobile phone number"
   }
-}) }}
+}) -}}
 {% endset -%}
 
 {{ modukRadios({
@@ -77,4 +77,4 @@
       }
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/radios/__examples__/with-divider-option.njk
+++ b/src/nunjucks/moduk/components/radios/__examples__/with-divider-option.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/radios/macro.njk" import modukRadios %}
+{% from "moduk/components/radios/macro.njk" import modukRadios -%}
 
 {{ modukRadios({
   name: "with-divider-option",
@@ -26,4 +26,4 @@
       text: "Register for a new account"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/radios/__examples__/with-error-message.njk
+++ b/src/nunjucks/moduk/components/radios/__examples__/with-error-message.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/radios/macro.njk" import modukRadios %}
+{% from "moduk/components/radios/macro.njk" import modukRadios -%}
 
 {{ modukRadios({
   name: "organisation-with-error",
@@ -30,4 +30,4 @@
       text: "Strategic Command"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/radios/__examples__/with-item-hint.njk
+++ b/src/nunjucks/moduk/components/radios/__examples__/with-item-hint.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/radios/macro.njk" import modukRadios %}
+{% from "moduk/components/radios/macro.njk" import modukRadios -%}
 
 {{ modukRadios({
   name: "sign-in-with-hint",
@@ -28,4 +28,4 @@
       }
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/radios/macro.njk
+++ b/src/nunjucks/moduk/components/radios/macro.njk
@@ -1,5 +1,5 @@
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/radios/macro.njk" import govukRadios -%}
 
-{% macro modukRadios(params) %}
+{% macro modukRadios(params) -%}
   {{ govukRadios(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/select/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/select/__examples__/default.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/select/macro.njk" import modukSelect %}
+{% from "moduk/components/select/macro.njk" import modukSelect -%}
 
 {{ modukSelect({
   id: "sort",
@@ -25,4 +25,4 @@
       text: "Most comments"
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/select/__examples__/with-hint.njk
+++ b/src/nunjucks/moduk/components/select/__examples__/with-hint.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/select/macro.njk" import modukSelect %}
+{% from "moduk/components/select/macro.njk" import modukSelect -%}
 
 {{ modukSelect({
   id: "subject",
@@ -52,4 +52,4 @@
       text: "Yorkshire and the Humber"
     }
    ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/select/macro.njk
+++ b/src/nunjucks/moduk/components/select/macro.njk
@@ -1,5 +1,5 @@
-{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/select/macro.njk" import govukSelect -%}
 
-{% macro modukSelect(params) %}
+{% macro modukSelect(params) -%}
   {{ govukSelect(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/skip-link/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/skip-link/__examples__/default.njk
@@ -1,12 +1,11 @@
 {%- from "moduk/components/skip-link/macro.njk" import modukSkipLink -%}
 
-{# Wrapped in a <div> so there is one root element, for visual regression tests to use #}
+{# Wrapped in a <div> so there is one root element, for visual regression tests to use -#}
 
 <div>
   <p class="govuk-body" id="content">To view the skip link component tab to this example, or click inside this example and press tab.</p>
-
   {{ modukSkipLink({
     text: "Skip to main content",
     href: "#content"
-  }) }}
+  }) -}}
 </div>

--- a/src/nunjucks/moduk/components/skip-link/macro.njk
+++ b/src/nunjucks/moduk/components/skip-link/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
 
-{% macro modukSkipLink(params) %}
+{% macro modukSkipLink(params) -%}
   {{ govukSkipLink(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/summary-list/__examples__/cards-with-action.njk
+++ b/src/nunjucks/moduk/components/summary-list/__examples__/cards-with-action.njk
@@ -1,4 +1,4 @@
-{%- from "moduk/components/summary-list/macro.njk" import modukSummaryList -%}
+{% from "moduk/components/summary-list/macro.njk" import modukSummaryList -%}
 
 <div>
 {{- modukSummaryList({
@@ -47,7 +47,7 @@
       }
     }
   ]
-}) }}
+}) -}}
 {{ modukSummaryList({
   card: {
     title: {

--- a/src/nunjucks/moduk/components/summary-list/__examples__/cards.njk
+++ b/src/nunjucks/moduk/components/summary-list/__examples__/cards.njk
@@ -1,4 +1,4 @@
-{%- from "moduk/components/summary-list/macro.njk" import modukSummaryList -%}
+{% from "moduk/components/summary-list/macro.njk" import modukSummaryList -%}
 
 <div>
 {{- modukSummaryList({
@@ -60,7 +60,7 @@
       }
     }
   ]
-}) }}
+}) -}}
 {{ modukSummaryList({
   card: {
     title: {
@@ -120,7 +120,7 @@
       }
     }
   ]
-}) }}
+}) -}}
 {{ modukSummaryList({
   card: {
     title: {

--- a/src/nunjucks/moduk/components/summary-list/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/summary-list/__examples__/default.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/summary-list/macro.njk" import modukSummaryList %}
+{% from "moduk/components/summary-list/macro.njk" import modukSummaryList -%}
 
 {{ modukSummaryList({
   rows: [
@@ -71,4 +71,4 @@
       }
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/summary-list/__examples__/with-no-actions.njk
+++ b/src/nunjucks/moduk/components/summary-list/__examples__/with-no-actions.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/summary-list/macro.njk" import modukSummaryList %}
+{% from "moduk/components/summary-list/macro.njk" import modukSummaryList -%}
 
 {{ modukSummaryList({
   rows: [
@@ -35,4 +35,4 @@
       }
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/summary-list/__examples__/with-no-border.njk
+++ b/src/nunjucks/moduk/components/summary-list/__examples__/with-no-border.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/summary-list/macro.njk" import modukSummaryList %}
+{% from "moduk/components/summary-list/macro.njk" import modukSummaryList -%}
 
 {{ modukSummaryList({
   classes: 'govuk-summary-list--no-border',
@@ -36,4 +36,4 @@
       }
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/summary-list/macro.njk
+++ b/src/nunjucks/moduk/components/summary-list/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% macro modukSummaryList(params) %}
+{% macro modukSummaryList(params) -%}
   {{ govukSummaryList(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/table/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/table/__examples__/default.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/table/macro.njk" import modukTable %}
+{% from "moduk/components/table/macro.njk" import modukTable -%}
 
 {{ modukTable({
   caption: "Active users of each application",
@@ -38,4 +38,4 @@
       }
     ]
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/table/__examples__/with-comparative-numbers.njk
+++ b/src/nunjucks/moduk/components/table/__examples__/with-comparative-numbers.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/table/macro.njk" import modukTable %}
+{% from "moduk/components/table/macro.njk" import modukTable -%}
 
 {{ modukTable({
   caption: "Users by role",
@@ -58,4 +58,4 @@
       }
     ]
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/table/__examples__/with-customised-column-widths.njk
+++ b/src/nunjucks/moduk/components/table/__examples__/with-customised-column-widths.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/table/macro.njk" import modukTable %}
+{% from "moduk/components/table/macro.njk" import modukTable -%}
 
 {{ modukTable({
   caption: "Active users by role",
@@ -53,4 +53,4 @@
       }
     ]
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/table/__examples__/with-large-caption.njk
+++ b/src/nunjucks/moduk/components/table/__examples__/with-large-caption.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/table/macro.njk" import modukTable %}
+{% from "moduk/components/table/macro.njk" import modukTable -%}
 
 {{ modukTable({
   caption: "Active users of each application",
@@ -38,4 +38,4 @@
       }
     ]
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/table/macro.njk
+++ b/src/nunjucks/moduk/components/table/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% macro modukTable(params) %}
+{% macro modukTable(params) -%}
   {{ govukTable(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/tabs/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/tabs/__examples__/default.njk
@@ -1,5 +1,5 @@
-{% from "moduk/components/tabs/macro.njk" import modukTabs %}
-{% from "moduk/components/table/macro.njk" import modukTable %}
+{% from "moduk/components/tabs/macro.njk" import modukTabs -%}
+{% from "moduk/components/table/macro.njk" import modukTable -%}
 
 {% set pastDayHtml %}
 <h2 class="govuk-heading-l">Past day</h2>
@@ -50,7 +50,7 @@
       }
     ]
   ]
-}) }}
+}) -}}
 {% endset -%}
 
 {% set pastWeekHtml %}
@@ -102,7 +102,7 @@
       }
     ]
   ]
-}) }}
+}) -}}
 {% endset -%}
 
 {% set pastMonthHtml %}
@@ -154,7 +154,7 @@
       }
     ]
   ]
-}) }}
+}) -}}
 {% endset -%}
 
 {% set pastYearHtml %}
@@ -206,7 +206,7 @@
       }
     ]
   ]
-}) }}
+}) -}}
 {% endset -%}
 
 {{ modukTabs({
@@ -240,4 +240,4 @@
       }
     }
   ]
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/tabs/macro.njk
+++ b/src/nunjucks/moduk/components/tabs/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 
-{% macro modukTabs(params) %}
+{% macro modukTabs(params) -%}
   {{ govukTabs(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/tag/__examples__/blue.njk
+++ b/src/nunjucks/moduk/components/tag/__examples__/blue.njk
@@ -1,6 +1,6 @@
-{%- from "moduk/components/tag/macro.njk" import modukTag -%}
+{% from "moduk/components/tag/macro.njk" import modukTag -%}
 
 {{ modukTag({
   text: "Pending",
   classes: "govuk-tag--blue"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/tag/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/tag/__examples__/default.njk
@@ -1,5 +1,5 @@
-{%- from "moduk/components/tag/macro.njk" import modukTag -%}
+{% from "moduk/components/tag/macro.njk" import modukTag -%}
 
 {{ modukTag({
   text: "Completed"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/tag/__examples__/green.njk
+++ b/src/nunjucks/moduk/components/tag/__examples__/green.njk
@@ -1,6 +1,6 @@
-{%- from "moduk/components/tag/macro.njk" import modukTag -%}
+{% from "moduk/components/tag/macro.njk" import modukTag -%}
 
 {{ modukTag({
   text: "New",
   classes: "govuk-tag--green"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/tag/__examples__/grey.njk
+++ b/src/nunjucks/moduk/components/tag/__examples__/grey.njk
@@ -1,6 +1,6 @@
-{%- from "moduk/components/tag/macro.njk" import modukTag -%}
+{% from "moduk/components/tag/macro.njk" import modukTag -%}
 
 {{ modukTag({
   text: "Inactive",
   classes: "govuk-tag--grey"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/tag/__examples__/orange.njk
+++ b/src/nunjucks/moduk/components/tag/__examples__/orange.njk
@@ -1,6 +1,6 @@
-{%- from "moduk/components/tag/macro.njk" import modukTag -%}
+{% from "moduk/components/tag/macro.njk" import modukTag -%}
 
 {{ modukTag({
   text: "Declined",
   classes: "govuk-tag--orange"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/tag/__examples__/pink.njk
+++ b/src/nunjucks/moduk/components/tag/__examples__/pink.njk
@@ -1,6 +1,6 @@
-{%- from "moduk/components/tag/macro.njk" import modukTag -%}
+{% from "moduk/components/tag/macro.njk" import modukTag -%}
 
 {{ modukTag({
   text: "Sent",
   classes: "govuk-tag--pink"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/tag/__examples__/purple.njk
+++ b/src/nunjucks/moduk/components/tag/__examples__/purple.njk
@@ -1,6 +1,6 @@
-{%- from "moduk/components/tag/macro.njk" import modukTag -%}
+{% from "moduk/components/tag/macro.njk" import modukTag -%}
 
 {{ modukTag({
   text: "Received",
   classes: "govuk-tag--purple"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/tag/__examples__/red.njk
+++ b/src/nunjucks/moduk/components/tag/__examples__/red.njk
@@ -1,6 +1,6 @@
-{%- from "moduk/components/tag/macro.njk" import modukTag -%}
+{% from "moduk/components/tag/macro.njk" import modukTag -%}
 
 {{ modukTag({
   text: "Rejected",
   classes: "govuk-tag--red"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/tag/__examples__/turquoise.njk
+++ b/src/nunjucks/moduk/components/tag/__examples__/turquoise.njk
@@ -1,6 +1,6 @@
-{%- from "moduk/components/tag/macro.njk" import modukTag -%}
+{% from "moduk/components/tag/macro.njk" import modukTag -%}
 
 {{ modukTag({
   text: "Active",
   classes: "govuk-tag--turquoise"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/tag/__examples__/yellow.njk
+++ b/src/nunjucks/moduk/components/tag/__examples__/yellow.njk
@@ -1,6 +1,6 @@
-{%- from "moduk/components/tag/macro.njk" import modukTag -%}
+{% from "moduk/components/tag/macro.njk" import modukTag -%}
 
 {{ modukTag({
   text: "Delayed",
   classes: "govuk-tag--yellow"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/tag/macro.njk
+++ b/src/nunjucks/moduk/components/tag/macro.njk
@@ -1,5 +1,5 @@
-{%- from "govuk/components/tag/macro.njk" import govukTag -%}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
 
-{% macro modukTag(params) %}
+{% macro modukTag(params) -%}
   {{ govukTag(params | addCustomMODUKClass("moduk-tag--default", { not: r/^govuk-tag--/ })) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/textarea/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/textarea/__examples__/default.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/textarea/macro.njk" import modukTextarea %}
+{% from "moduk/components/textarea/macro.njk" import modukTextarea -%}
 
 {{ modukTextarea({
   name: "event-description",
@@ -11,4 +11,4 @@
   hint: {
     text: "This will be shown on the public page for the event, below the event title"
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/textarea/__examples__/not-as-page-heading.njk
+++ b/src/nunjucks/moduk/components/textarea/__examples__/not-as-page-heading.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/textarea/macro.njk" import modukTextarea %}
+{% from "moduk/components/textarea/macro.njk" import modukTextarea -%}
 
 {{ modukTextarea({
   name: "event-description-not-as-page-heading",
@@ -6,4 +6,4 @@
   label: {
     text: "What is the event about?"
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/textarea/__examples__/with-custom-height.njk
+++ b/src/nunjucks/moduk/components/textarea/__examples__/with-custom-height.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/textarea/macro.njk" import modukTextarea %}
+{% from "moduk/components/textarea/macro.njk" import modukTextarea -%}
 
 {{ modukTextarea({
   name: "event-description-custom-height",
@@ -12,4 +12,4 @@
   hint: {
     text: "This will be shown on the public page for the event, below the event title"
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/textarea/__examples__/with-error.njk
+++ b/src/nunjucks/moduk/components/textarea/__examples__/with-error.njk
@@ -1,4 +1,4 @@
-{% from "moduk/components/textarea/macro.njk" import modukTextarea %}
+{% from "moduk/components/textarea/macro.njk" import modukTextarea -%}
 
 {{ modukTextarea({
   name: "event-description-with-error",
@@ -14,4 +14,4 @@
   errorMessage: {
     text: "Enter some details about the event"
   }
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/textarea/macro.njk
+++ b/src/nunjucks/moduk/components/textarea/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
-{% macro modukTextarea(params) %}
+{% macro modukTextarea(params) -%}
   {{ govukTextarea(params) }}
-{% endmacro %}
+{%- endmacro %}

--- a/src/nunjucks/moduk/components/warning-text/__examples__/default.njk
+++ b/src/nunjucks/moduk/components/warning-text/__examples__/default.njk
@@ -1,6 +1,6 @@
-{%- from "moduk/components/warning-text/macro.njk" import modukWarningText -%}
+{% from "moduk/components/warning-text/macro.njk" import modukWarningText -%}
 
 {{ modukWarningText({ 
   text: "This operation cannot be undone when complete.",
   iconFallbackText: "Warning"
-}) }}
+}) -}}

--- a/src/nunjucks/moduk/components/warning-text/macro.njk
+++ b/src/nunjucks/moduk/components/warning-text/macro.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% macro modukWarningText(params) %}
+{% macro modukWarningText(params) -%}
   {{ govukWarningText(params) }}
-{% endmacro %}
+{%- endmacro %}


### PR DESCRIPTION
This adds whitespace control to all Nunjucks macros and the component examples. I've tried to only add it in places where it is needed and makes sense.

Note there are some special considerations in some contexts.

For macros, things outside the macro don't matter, as the entire file isn't included. `{% set -%}` also seemed to have no effect.

There is still whitespace remaining as the GOV.UK components themselves emit some.