### PR TITLE
chore(lint-types): Exclude examples-site/dist

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["**/dist", "node_modules"]
 }


### PR DESCRIPTION
`examples-site/dist` wasn't being excluded when `npm run lint:types` ran, causing incorrect failures to be reported.