### PR TITLE
feat(styles): Add full MOD.UK colour palette

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "postcss-fail-on-warn": "^0.2.1",
         "release-it": "^15.7.0",
         "sass": "^1.59.3",
+        "sass-true": "^7.0.0",
         "shx": "^0.3.4",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.5",
@@ -3698,6 +3699,12 @@
         "@types/chai": "*"
       }
     },
+    "node_modules/@types/css": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/css/-/css-0.0.33.tgz",
+      "integrity": "sha512-qjeDgh86R0LIeEM588q65yatc8Yyo/VvSIYFqq8JOIHDolhGNX0rz7k/OuxqDpnpqlefoHj8X4Ai/6hT9IWtKQ==",
+      "dev": true
+    },
     "node_modules/@types/eslint": {
       "version": "8.21.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.1.tgz",
@@ -4926,6 +4933,18 @@
       "dev": true,
       "dependencies": {
         "retry": "0.13.1"
+      }
+    },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true,
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
       }
     },
     "node_modules/autoprefixer": {
@@ -6261,6 +6280,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/css": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+      "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.6.0"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -6343,6 +6373,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decode-uri-component": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/decompress-response": {
@@ -14557,6 +14596,24 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/sass-true": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/sass-true/-/sass-true-7.0.0.tgz",
+      "integrity": "sha512-sRdXX7MrrYdg+lPRm+/vIr8wVvDrNtWj3ttOVyIMHZQ8vNoV67+YjZKTsY9+B4Ecee+/U3ryXKJLi1YcMEkaJQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/css": "^0.0.33",
+        "css": "^3.0.0",
+        "jest-diff": "^29.3.1",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "sass": ">=1.45.0"
+      }
+    },
     "node_modules/schema-utils": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
@@ -14876,6 +14933,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-resolve": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+      "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+      "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+      "dev": true,
+      "dependencies": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0"
       }
     },
     "node_modules/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "postcss-fail-on-warn": "^0.2.1",
     "release-it": "^15.7.0",
     "sass": "^1.59.3",
+    "sass-true": "^7.0.0",
     "shx": "^0.3.4",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5",

--- a/src/css/__tests__/_colour-palette.test.scss
+++ b/src/css/__tests__/_colour-palette.test.scss
@@ -1,0 +1,42 @@
+@use 'sass-true' as test;
+@use '../colour-palette' as moduk;
+
+@include test.describe('moduk-colour') {
+  @include test.it('returns untinted colours') {
+    @include test.assert-equal(moduk.moduk-colour('dark-purple'), #532a45);
+    @include test.assert-equal(moduk.moduk-colour('dark-grey'), #323e48);
+    @include test.assert-equal(moduk.moduk-colour('dark-blue'), #13284c);
+    @include test.assert-equal(moduk.moduk-colour('dark-green'), #153e35);
+    @include test.assert-equal(moduk.moduk-colour('dark-yellow'), #f6a800);
+    @include test.assert-equal(moduk.moduk-colour('dark-orange'), #e0592b);
+    @include test.assert-equal(moduk.moduk-colour('dark-pink'), #8e1537);
+    @include test.assert-equal(moduk.moduk-colour('muted-purple'), #94368d);
+    @include test.assert-equal(moduk.moduk-colour('muted-grey'), #7b98ac);
+    @include test.assert-equal(moduk.moduk-colour('muted-blue'), #4298cc);
+    @include test.assert-equal(moduk.moduk-colour('muted-green'), #00945f);
+    @include test.assert-equal(moduk.moduk-colour('muted-yellow'), #ffc845);
+    @include test.assert-equal(moduk.moduk-colour('muted-orange'), #f28b00);
+    @include test.assert-equal(moduk.moduk-colour('muted-pink'), #fa7699);
+    @include test.assert-equal(moduk.moduk-colour('bright-purple'), #ab92e1);
+    @include test.assert-equal(moduk.moduk-colour('bright-grey'), #becdd6);
+    @include test.assert-equal(moduk.moduk-colour('bright-blue'), #3db5e6);
+    @include test.assert-equal(moduk.moduk-colour('bright-green'), #00ce7d);
+    @include test.assert-equal(moduk.moduk-colour('bright-yellow'), #ffc600);
+    @include test.assert-equal(moduk.moduk-colour('bright-orange'), #ff8200);
+    @include test.assert-equal(moduk.moduk-colour('bright-pink'), #f087cf);
+    @include test.assert-equal(moduk.moduk-colour('light-maroon'), #643f58);
+    @include test.assert-equal(moduk.moduk-colour('maroon'), #532a45);
+    @include test.assert-equal(moduk.moduk-colour('dark-maroon'), #4b263e);
+  }
+
+  @include test.it('returns tinted colours') {
+    @include test.assert-equal(moduk.moduk-colour('dark-purple', 80), #75556a);
+    @include test.assert-equal(moduk.moduk-colour('dark-purple', 60), #987f8f);
+    @include test.assert-equal(moduk.moduk-colour('dark-purple', 40), #baaab5);
+    @include test.assert-equal(moduk.moduk-colour('dark-purple', 20), #ddd4da);
+    @include test.assert-equal(moduk.moduk-colour('dark-grey', 80), #5b656d);
+    @include test.assert-equal(moduk.moduk-colour('dark-grey', 60), #848b91);
+    @include test.assert-equal(moduk.moduk-colour('dark-grey', 40), #adb2b6);
+    @include test.assert-equal(moduk.moduk-colour('dark-grey', 20), #d6d8da);
+  }
+}

--- a/src/css/__tests__/index.test.ts
+++ b/src/css/__tests__/index.test.ts
@@ -1,0 +1,17 @@
+// @vitest-environment node
+
+import { globSync } from 'glob'
+import { join } from 'node:path'
+import sassTrue from 'sass-true'
+import { describe, it } from 'vitest'
+
+globSync(join(__dirname, '**/*.test.scss'), { windowsPathsNoEscape: true }).forEach((filePath) => {
+  sassTrue.runSass(
+    { describe, it },
+    filePath,
+    {
+      loadPaths: ['node_modules'],
+      quietDeps: true,
+    },
+  )
+})

--- a/src/css/_colour-palette.scss
+++ b/src/css/_colour-palette.scss
@@ -1,15 +1,67 @@
+@use 'sass:color';
+@use 'sass:list';
+@use 'sass:map';
+
+@use 'govuk-frontend/govuk/helpers/colour';
+
 $moduk-colours: (
-  'maroon': #532a45,
+  'dark-purple': #532a45,
+  'dark-grey': #323e48,
+  'dark-blue': #13284c,
+  'dark-green': #153e35,
+  'dark-yellow': #f6a800,
+  'dark-orange': #e0592b,
+  'dark-pink': #8e1537,
+  'muted-purple': #94368d,
+  'muted-grey': #7b98ac,
+  'muted-blue': #4298cc,
+  'muted-green': #00945f,
+  'muted-yellow': #ffc845,
+  'muted-orange': #f28b00,
+  'muted-pink': #fa7699,
+  'bright-purple': #ab92e1,
+  'bright-grey': #becdd6,
+  'bright-blue': #3db5e6,
+  'bright-green': #00ce7d,
+  'bright-yellow': #ffc600,
+  'bright-orange': #ff8200,
+  'bright-pink': #f087cf,
+);
+
+$legacy-moduk-colours: (
+  'maroon': map-get($moduk-colours, 'dark-purple'),
   'dark-maroon': #4b263e,
   'light-maroon': #643f58,
 );
 
-@function moduk-colour($colour-name) {
+// Get a colour from the MOD.UK colour palette.
+//
+// @param $colour-name {String} the name of the colour (e.g. dark-purple, muted-blue)
+// @param $tint {Number} Optional colour tint (80, 60, 40 or 20)
+//
+// @return {String}
+@function moduk-colour($colour-name, $tint: null) {
+  $valid_tints: [20, 40, 60, 80];
   $quoted-colour-name: quote($colour-name);
+  $all_colours: map.merge($legacy-moduk-colours, $moduk-colours);
 
-  @if not map-has-key($moduk-colours, $quoted-colour-name) {
+  @if $tint and not list.index($valid_tints, $tint) {
+    @error "Invalid tint `#{$tint}`";
+  }
+
+  @if not map.has-key($all_colours, $quoted-colour-name) {
     @error "Unknown colour `#{$quoted-colour-name}`";
   }
 
-  @return map-get($moduk-colours, $quoted-colour-name);
+  @if $tint and map.has-key($legacy-moduk-colours, $quoted-colour-name) {
+    @error "Invalid tint `#{$tint}` for colour `#{$quoted-colour-name}`";
+  }
+
+  $resolved_colour: map.get($all_colours, $quoted-colour-name);
+
+  @if $tint {
+    @return colour.govuk-tint($resolved_colour, 100 - $tint);
+  }
+
+  @return $resolved_colour;
 }


### PR DESCRIPTION
This expands the existing `moduk-colour` Sass function to:

- add the full set of MOD.UK colours
- add the ability to get 80%, 60%, 40% and 20% tints

The existing colours have been maintained to preserve backwards compatibility, and moved to a separate map specifically for legacy colours.

Unit tests using the sass-true library have also been added. These run along with the rest of the unit test suite (using vitest).

(Note there is no way to test `#error` uses, as it terminates Sass compilation.)