### PR TITLE
deps-dev: Add missing @types/node dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@testing-library/dom": "^9.0.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@types/lodash": "^4.14.191",
+        "@types/node": "^18.15.11",
         "@types/nunjucks": "^3.2.2",
         "@typescript-eslint/eslint-plugin": "^5.55.0",
         "@typescript-eslint/parser": "^5.57.0",
@@ -3828,9 +3829,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.14.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.6.tgz",
-      "integrity": "sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==",
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@testing-library/dom": "^9.0.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@types/lodash": "^4.14.191",
+    "@types/node": "^18.15.11",
     "@types/nunjucks": "^3.2.2",
     "@typescript-eslint/eslint-plugin": "^5.55.0",
     "@typescript-eslint/parser": "^5.57.0",


### PR DESCRIPTION
`@types/node` wasn't installed, even though it's referenced in `tsconfig.json`. I believe this was just an oversight.