### PR TITLE
build: Include React examples in built package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "sass-true": "^7.0.0",
         "shx": "^0.3.4",
         "ts-node": "^10.9.1",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "^5.0.4",
         "vitest": "^0.29.2",
         "webpack": "^5.76.3",
@@ -8139,6 +8140,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -8146,6 +8159,18 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/tsconfig-paths": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+      "dev": true,
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
       }
     },
     "node_modules/eslint-plugin-unicorn": {
@@ -17326,27 +17351,17 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "dev": true,
       "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.2",
+        "json5": "^2.2.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
       },
-      "bin": {
-        "json5": "lib/cli.js"
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "style": "dist/css/index.css",
   "files": [
     "dist",
-    "src/css"
+    "src/css",
+    "src/react/**/__examples__/**"
   ],
   "exports": {
     ".": {
@@ -21,7 +22,7 @@
       "require": "./dist/client/moduk-frontend.umd.js"
     },
     "./dist/*": "./dist/*",
-    "./src/css/*": "./src/css/*"
+    "./src/*": "./src/*"
   },
   "types": "dist/lib/index.d.ts",
   "scripts": {
@@ -125,6 +126,7 @@
     "sass-true": "^7.0.0",
     "shx": "^0.3.4",
     "ts-node": "^10.9.1",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.0.4",
     "vitest": "^0.29.2",
     "webpack": "^5.76.3",

--- a/src/react/back-link/__examples__/default.tsx
+++ b/src/react/back-link/__examples__/default.tsx
@@ -1,3 +1,3 @@
-import { BackLink } from '../BackLink'
+import { BackLink } from '@moduk/frontend/react'
 
-export default () => <BackLink>Back</BackLink>
+export default () => <BackLink href='#'>Back</BackLink>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,15 @@
     "strict": true,
     "skipLibCheck": true,
     "types": ["node"],
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "@moduk/frontend/react": [
+        "./src/react/"
+      ]
+    }
   },
-  "exclude": ["**/dist", "node_modules"]
+  "exclude": ["**/dist", "node_modules"],
+  "ts-node": {
+    "require": ["tsconfig-paths/register"]
+  }
 }

--- a/webpack-react.config.ts
+++ b/webpack-react.config.ts
@@ -39,6 +39,9 @@ const config: Configuration = {
     path: path.resolve(__dirname, './examples-site/dist/react-example-client'),
   },
   resolve: {
+    alias: {
+      '@moduk/frontend/react': path.resolve(__dirname, 'src/react/'),
+    },
     extensions: ['.ts', '.tsx', '.mjs', '...'],
   },
 }


### PR DESCRIPTION
This updates the `files` and `exports` package.json properties so that the React examples are included in the built package, and can be resolved or imported from the https://github.com/defencedigital/moduk-frontend-guidance-site/.

It also makes the React examples use external imports so that they can serve as standalone examples and be reused for the code snippets. This required configuring aliases in Webpack and TypeScript.
