### PR TITLE
feat: Update GOV.UK Frontend to version 4.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,7 @@
         "npm": ">=8.15.0"
       },
       "peerDependencies": {
-        "govuk-frontend": "4.6.0",
+        "govuk-frontend": "4.7.0",
         "nunjucks": "^3.2.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -10675,9 +10675,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.6.0.tgz",
-      "integrity": "sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "peer": true,
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "optionator": "^0.9.3"
   },
   "peerDependencies": {
-    "govuk-frontend": "4.6.0",
+    "govuk-frontend": "4.7.0",
     "nunjucks": "^3.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
This updates GOV.UK Frontend to [version 4.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0).