### PR TITLE
ci(dependabot): Add grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,19 @@ updates:
     commit-message:
       prefix: 'deps:'
       prefix-development: 'deps-dev:'
+    groups:
+      babel:
+        patterns:
+          - '@babel/*'
+      commitlint:
+        patterns:
+          - '@commitlint/*'
+      testing-library:
+        patterns:
+          - '@testing-library/*'
+      typescript-eslint:
+        patterns:
+          - '@typescript-eslint/*'
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
This enables grouped updates for a few of the main groups of dependencies that are normally updated together.

I haven't included babel-loader and the babel plugins in the babel group for now, as we probably wouldn't want to group those for major updates.