### PR TITLE
feat(header): Add support for router links to React component

### DIFF
--- a/src/react/header/HeaderNavigationItem.tsx
+++ b/src/react/header/HeaderNavigationItem.tsx
@@ -1,31 +1,33 @@
 import clsx from 'clsx'
-import type { JSX, ReactNode } from 'react'
+import { forwardRef, type ReactNode } from 'react'
 
 export interface HeaderNavigationItemProps {
   children: ReactNode
+  className?: string
   active?: boolean
 }
 
-export function HeaderNavigationItem(
-  { active, children, className, ...props }: HeaderNavigationItemProps & JSX.IntrinsicElements['a'],
-) {
-  return (
-    <>
-      <li
-        className={clsx(
-          'govuk-header__navigation-item',
-          active && 'govuk-header__navigation-item--active moduk-header__navigation-item--active',
-        )}
-      >
-        {typeof children === 'string'
-          ? (
-            <a className={clsx('govuk-header__link', className)} {...props}>
-              {children}
-            </a>
-          )
-          : children}
-      </li>
-      {/* Match the whitespace for as the Nunjucks version */ ' '}
-    </>
-  )
-}
+export const HeaderNavigationItem = forwardRef<
+  HTMLLIElement,
+  HeaderNavigationItemProps
+>((
+  { active, children, className, ...props },
+  ref,
+) => (
+  <>
+    <li
+      ref={ref}
+      className={clsx(
+        'govuk-header__navigation-item',
+        active && 'govuk-header__navigation-item--active moduk-header__navigation-item--active',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </li>
+    {/* Match the whitespace for as the Nunjucks version */ ' '}
+  </>
+))
+
+HeaderNavigationItem.displayName = 'HeaderNavigationItem'

--- a/src/react/header/HeaderNavigationLink.tsx
+++ b/src/react/header/HeaderNavigationLink.tsx
@@ -1,0 +1,22 @@
+import clsx from 'clsx'
+import { forwardRef, type ReactNode } from 'react'
+import { LinkBase, type LinkComponent } from '../internal/Link/Link'
+
+export interface HeaderNavigationLinkProps {
+  children: ReactNode
+  className?: string
+}
+
+export const HeaderNavigationLink: LinkComponent<HeaderNavigationLinkProps> = forwardRef<
+  HTMLAnchorElement,
+  HeaderNavigationLinkProps
+>((
+  { children, className, ...props },
+  ref,
+) => (
+  <LinkBase ref={ref} className={clsx('govuk-header__link', className)} {...props}>
+    {children}
+  </LinkBase>
+))
+
+HeaderNavigationLink.displayName = 'HeaderNavigationLink'

--- a/src/react/header/__examples__/with-service-name-and-navigation.tsx
+++ b/src/react/header/__examples__/with-service-name-and-navigation.tsx
@@ -1,4 +1,4 @@
-import { Header, HeaderNavigationItem } from '@moduk/frontend/react'
+import { Header, HeaderNavigationItem, HeaderNavigationLink } from '@moduk/frontend/react'
 
 export const Example = () => (
   <Header
@@ -6,9 +6,17 @@ export const Example = () => (
     serviceName='Service name'
     serviceUrl='#'
   >
-    <HeaderNavigationItem active href='#1'>Navigation item 1</HeaderNavigationItem>
-    <HeaderNavigationItem href='#2'>Navigation item 2</HeaderNavigationItem>
-    <HeaderNavigationItem href='#3'>Navigation item 3</HeaderNavigationItem>
-    <HeaderNavigationItem href='#4'>Navigation item 4</HeaderNavigationItem>
+    <HeaderNavigationItem active>
+      <HeaderNavigationLink href='#1'>Navigation item 1</HeaderNavigationLink>
+    </HeaderNavigationItem>
+    <HeaderNavigationItem>
+      <HeaderNavigationLink href='#2'>Navigation item 2</HeaderNavigationLink>
+    </HeaderNavigationItem>
+    <HeaderNavigationItem>
+      <HeaderNavigationLink href='#3'>Navigation item 3</HeaderNavigationLink>
+    </HeaderNavigationItem>
+    <HeaderNavigationItem>
+      <HeaderNavigationLink href='#4'>Navigation item 4</HeaderNavigationLink>
+    </HeaderNavigationItem>
   </Header>
 )

--- a/src/react/header/__tests__/Header.test.tsx
+++ b/src/react/header/__tests__/Header.test.tsx
@@ -1,0 +1,24 @@
+import { Header, HeaderNavigationItem, HeaderNavigationLink } from '@moduk/frontend/react'
+import { render } from '@testing-library/react'
+import type { JSX, ReactNode } from 'react'
+import { describe, expect, test } from 'vitest'
+
+const RouterLink = ({ to, children }: { to: string; children: ReactNode }): JSX.Element => <a href={to}>{children}</a>
+
+describe('Header', () => {
+  test('renders custom link components', () => {
+    const { getByText } = render(
+      <Header
+        homepageUrl='#'
+        serviceName='Service name'
+        serviceUrl='#'
+      >
+        <HeaderNavigationItem active>
+          <HeaderNavigationLink component={RouterLink} to='#1'>Navigation item 1</HeaderNavigationLink>
+        </HeaderNavigationItem>
+      </Header>,
+    )
+
+    expect(getByText('Navigation item 1')).toHaveAttribute('href', '#1')
+  })
+})

--- a/src/react/header/index.ts
+++ b/src/react/header/index.ts
@@ -1,0 +1,3 @@
+export * from './Header'
+export * from './HeaderNavigationItem'
+export * from './HeaderNavigationLink'

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -2,6 +2,5 @@
 
 export * from './accordion'
 export * from './back-link/BackLink'
-export * from './header/Header'
-export * from './header/HeaderNavigationItem'
+export * from './header'
 export * from './MODUKBody/MODUKBody'


### PR DESCRIPTION
The React version of the header component was missing native support for router links. This adds in a similar way to other components.