### PR TITLE
ci(e2e): Merge Playwright shard reports

### DIFF
--- a/.github/actions/merge-playwright-reports/action.yml
+++ b/.github/actions/merge-playwright-reports/action.yml
@@ -1,0 +1,27 @@
+name: Merge sharded Playwright blob reports
+description: Merges sharded Playwright blob reports
+inputs:
+  input-artifact:
+    required: true
+    description: Name of the artefact containing blob reports
+  output-artifact:
+    required: true
+    description: Name of the artefact to save the HTML report as
+runs:
+  using: composite
+  steps:
+    - name: Download blob reports
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.input-artifact }}
+        path: blob-reports
+
+    - name: Merge reports
+      shell: bash
+      run: npm exec --no -- playwright merge-reports --reporter html blob-reports
+
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: ${{ inputs.output-artifact }}
+        path: playwright-report

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -86,11 +86,11 @@ jobs:
       - name: Run unit tests
         run: npm run test
 
-  read-playwright-version:
-    name: Read Playwright version
+  determine-playwright-image:
+    name: Determine Playwright container image
     runs-on: ubuntu-22.04
     outputs:
-      version: ${{ steps.read-version.outputs.version }}
+      container-image: mcr.microsoft.com/playwright:${{ steps.read-version.outputs.version }}-jammy
     steps:
       - name: Git clone repository
         uses: actions/checkout@v3
@@ -104,14 +104,14 @@ jobs:
     name: Run e2e tests (${{ matrix.shard }}/${{ matrix.total_shards }})
     runs-on: ubuntu-22.04
     needs:
-      - read-playwright-version
+      - determine-playwright-image
     container:
-      image: mcr.microsoft.com/playwright:${{ needs.read-playwright-version.outputs.version }}-jammy
+      image: ${{ needs.determine-playwright-image.outputs.container-image }}
       options: --user 1001
     strategy:
       matrix:
-        shard: [1, 2, 3]
-        total_shards: [3]
+        shard: [1, 2, 3, 4]
+        total_shards: [4]
     steps:
       - name: Git clone repository
         uses: actions/checkout@v3
@@ -125,17 +125,42 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: e2e-test-results-${{ matrix.shard }}
-          path: e2e/output
+          name: e2e-blob-reports
+          path: blob-report
+          retention-days: 1
+
+  merge-e2e-reports:
+    name: Merge e2e test reports
+    runs-on: ubuntu-22.04
+    if: always()
+    needs:
+      - determine-playwright-image
+      - test-e2e
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
+
+      - name: Merge reports
+        uses: ./.github/actions/merge-playwright-reports
+        with:
+          input-artifact: e2e-blob-reports
+          output-artifact: e2e-html-report
 
   test-visual-regression:
-    name: Run visual regression tests
+    name: Run visual regression tests (${{ matrix.shard }}/${{ matrix.total_shards }})
     runs-on: ubuntu-22.04
     needs:
-      - read-playwright-version
+      - determine-playwright-image
     container:
-      image: mcr.microsoft.com/playwright:${{ needs.read-playwright-version.outputs.version }}-jammy
+      image: ${{ needs.determine-playwright-image.outputs.container-image }}
       options: --user 1001
+    strategy:
+      matrix:
+        shard: [1, 2]
+        total_shards: [2]
     steps:
       - name: Git clone repository
         uses: actions/checkout@v3
@@ -144,13 +169,34 @@ jobs:
         uses: ./.github/actions/prepare-environment
 
       - name: Run visual regression tests
-        run: npm run test:visual:native
+        run: npm run test:visual:native -- --shard ${{ matrix.shard }}/${{ matrix.total_shards }}
 
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: visual-regression-test-results
-          path: e2e/output
+          name: visual-regression-blob-reports
+          path: blob-report
+          retention-days: 1
+
+  merge-visual-regression-reports:
+    name: Merge visual regression reports
+    runs-on: ubuntu-22.04
+    if: always()
+    needs:
+      - determine-playwright-image
+      - test-visual-regression
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v3
+
+      - name: Set up environment
+        uses: ./.github/actions/prepare-environment
+
+      - name: Merge reports
+        uses: ./.github/actions/merge-playwright-reports
+        with:
+          input-artifact: visual-regression-blob-reports
+          output-artifact: visual-regression-html-report
 
   audit-dependencies:
     name: Audit dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ dist
 .tern-port
 
 /e2e/output/
+/blob-report/
 
 # Editor configs 
 .vscode/

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@babel/register": "^7.22.5",
         "@commitlint/cli": "^17.7.1",
         "@commitlint/config-conventional": "^17.7.0",
-        "@playwright/test": "^1.36.2",
+        "@playwright/test": "^1.37.0",
         "@release-it/conventional-changelog": "^6.0.0",
         "@testing-library/dom": "^9.3.1",
         "@testing-library/jest-dom": "^6.0.0",
@@ -4375,13 +4375,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.36.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.36.2.tgz",
-      "integrity": "sha512-2rVZeyPRjxfPH6J0oGJqE8YxiM1IBRyM8hyrXYK7eSiAqmbNhxwcLa7dZ7fy9Kj26V7FYia5fh9XJRq4Dqme+g==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.0.tgz",
+      "integrity": "sha512-181WBLk4SRUyH1Q96VZl7BP6HcK0b7lbdeKisn3N/vnjitk+9HbdlFz/L5fey05vxaAhldIDnzo8KUoy8S3mmQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.36.2"
+        "playwright-core": "1.37.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -14640,9 +14640,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.36.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.36.2.tgz",
-      "integrity": "sha512-sQYZt31dwkqxOrP7xy2ggDfEzUxM1lodjhsQ3NMMv5uGTRDsLxU0e4xf4wwMkF2gplIxf17QMBCodSFgm6bFVQ==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.0.tgz",
+      "integrity": "sha512-1c46jhTH/myQw6sesrcuHVtLoSNfJv8Pfy9t3rs6subY7kARv0HRw5PpyfPYPpPtQvBOmgbE6K+qgYUpj81LAA==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "@babel/register": "^7.22.5",
     "@commitlint/cli": "^17.7.1",
     "@commitlint/config-conventional": "^17.7.0",
-    "@playwright/test": "^1.36.2",
+    "@playwright/test": "^1.37.0",
     "@release-it/conventional-changelog": "^6.0.0",
     "@testing-library/dom": "^9.3.1",
     "@testing-library/jest-dom": "^6.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -148,10 +148,12 @@ const config: PlaywrightTestConfig = {
       },
     },
   ]),
-  reporter: [
-    [process.env.CI ? 'github' : 'line'],
-    ['html', { outputFolder: './e2e/output/html/', open: 'never' }],
-  ],
+  reporter: process.env.CI
+    ? [['blob'], ['github']]
+    : [
+      ['line'],
+      ['html', { outputFolder: './e2e/output/html/', open: 'never' }],
+    ],
   retries: process.env.CI ? 1 : 0,
   snapshotPathTemplate: '{testDir}/__screenshots__/{testFilePath}/{arg}--{projectName}{ext}',
   testDir: './e2e/tests',


### PR DESCRIPTION
This updates to Playwright 1.37.0 and makes use of [new functionality to merge reports across shards](https://playwright.dev/docs/test-sharding#merging-reports-from-multiple-shards). The number of shards for the e2e tests was also increased by one, and sharding was added to the visual regression tests (two shards only).