### PR TITLE
feat(input): Add React implementation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
     'unicorn',
   ],
   rules: {
-    '@typescript-eslint/consistent-type-imports': 'error',
+    '@typescript-eslint/consistent-type-imports': ['error', { fixStyle: 'inline-type-imports' }],
     'comma-dangle': 'off',
     'eslint-comments/no-unused-disable': 'error',
     'eslint-comments/disable-enable-pair': ['error', { allowWholeFile: true }],
@@ -62,6 +62,7 @@ module.exports = {
     'max-len': 'off',
     'no-extra-semi': 'off',
     'object-curly-newline': 'off',
+    'react/jsx-no-constructed-context-values': 'error',
     semi: ['error', 'never'],
     'semi-style': 'off',
     'unicorn/prefer-node-protocol': 'error',

--- a/e2e/tests/components/input/with-error.spec.ts
+++ b/e2e/tests/components/input/with-error.spec.ts
@@ -11,7 +11,11 @@ test.describe('input, with error', () => {
     ).toHaveText('What is the name of the event?')
   })
 
-  test('displays the error message', async ({ page }) => {
+  test('has an accessible error message', async ({ page }) => {
     await expect(page.getByRole('textbox')).toHaveDescription('Error: Enter an event name')
+  })
+
+  test('has an accessible hint', async ({ page }) => {
+    await expect(page.getByRole('textbox')).toHaveDescription('The name you’ll use on promotional material')
   })
 })

--- a/e2e/tests/components/input/with-hint.spec.ts
+++ b/e2e/tests/components/input/with-hint.spec.ts
@@ -10,4 +10,8 @@ test.describe('input, with hint', () => {
       page.getByText('The name you’ll use on promotional material'),
     ).toBeVisible()
   })
+
+  test('has an accessible hint', async ({ page }) => {
+    await expect(page.getByRole('textbox')).toHaveDescription('The name you’ll use on promotional material')
+  })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@testing-library/dom": "^9.3.1",
         "@testing-library/jest-dom": "^6.0.1",
         "@testing-library/react": "^14.0.0",
+        "@testing-library/user-event": "^14.4.3",
         "@types/lodash": "^4.14.195",
         "@types/node": "^18.16.19",
         "@types/nunjucks": "^3.2.3",
@@ -4759,6 +4760,19 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@testing-library/dom": "^9.3.1",
     "@testing-library/jest-dom": "^6.0.1",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/lodash": "^4.14.195",
     "@types/node": "^18.16.19",
     "@types/nunjucks": "^3.2.3",

--- a/src/react/accordion/Accordion.tsx
+++ b/src/react/accordion/Accordion.tsx
@@ -3,7 +3,7 @@
 import clsx from 'clsx'
 import { isEqual, pick } from 'lodash'
 import type { ComponentPropsWithoutRef } from 'react'
-import { Children, forwardRef, isValidElement, useRef } from 'react'
+import { Children, forwardRef, isValidElement, useMemo, useRef } from 'react'
 import flattenChildren from 'react-keyed-flatten-children'
 
 import { mergeRefs } from 'react-merge-refs'
@@ -75,6 +75,8 @@ export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
       ...rest
     } = props
 
+    const contextValue = useMemo(() => ({ headingTag, id }), [headingTag, id])
+
     const i18nAttributes = {
       'data-i18n.hide-all-sections': hideAllSectionsText,
       'data-i18n.hide-section': hideSectionText,
@@ -85,7 +87,7 @@ export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
     }
 
     return (
-      <AccordionContext.Provider value={{ headingTag, id }}>
+      <AccordionContext.Provider value={contextValue}>
         <div
           ref={mergeRefs([ref, forwardedRef])}
           key={key.current}

--- a/src/react/error-message/ErrorMessage.tsx
+++ b/src/react/error-message/ErrorMessage.tsx
@@ -1,0 +1,34 @@
+import clsx from 'clsx'
+import { type ComponentPropsWithoutRef, forwardRef, type ReactNode, useContext } from 'react'
+import { FormGroupContext } from '../internal/FormGroup'
+
+export interface ErrorMessageProps extends ComponentPropsWithoutRef<'p'> {
+  children: ReactNode
+  /**
+   * A visually hidden prefix used before the error message.
+   */
+  visuallyHiddenText?: string
+}
+
+/**
+ * @experimental React components are in alpha and subject to change.
+ */
+export const ErrorMessage = forwardRef<HTMLParagraphElement, ErrorMessageProps>(
+  ({ children, className, id, visuallyHiddenText = 'Error', ...rest }, ref) => {
+    const context = useContext(FormGroupContext)
+
+    return (
+      <p
+        ref={ref}
+        className={clsx('govuk-error-message', className)}
+        {...rest}
+        id={context.id ? `${context.id}-error` : id}
+      >
+        {visuallyHiddenText && <span className='govuk-visually-hidden'>{visuallyHiddenText}:</span>}
+        {children}
+      </p>
+    )
+  },
+)
+
+ErrorMessage.displayName = 'ErrorMessage'

--- a/src/react/error-message/__examples__/default.tsx
+++ b/src/react/error-message/__examples__/default.tsx
@@ -1,0 +1,3 @@
+import { ErrorMessage } from '@moduk/frontend/react'
+
+export const Example = () => <ErrorMessage>Enter a first name</ErrorMessage>

--- a/src/react/error-message/index.ts
+++ b/src/react/error-message/index.ts
@@ -1,0 +1,1 @@
+export * from './ErrorMessage'

--- a/src/react/hint/Hint.tsx
+++ b/src/react/hint/Hint.tsx
@@ -1,0 +1,24 @@
+import clsx from 'clsx'
+import { type ComponentPropsWithoutRef, forwardRef, type ReactNode, useContext } from 'react'
+import { FormGroupContext } from '../internal/FormGroup'
+
+export interface HintProps extends ComponentPropsWithoutRef<'div'> {
+  children: ReactNode
+}
+
+/**
+ * Hint for a form element.
+ *
+ * @experimental React components are in alpha and subject to change.
+ */
+export const Hint = forwardRef<HTMLDivElement, HintProps>(({ children, className, id, ...rest }, ref) => {
+  const context = useContext(FormGroupContext)
+
+  return (
+    <div ref={ref} className={clsx('govuk-hint', className)} id={context.id ? `${context.id}-hint` : id} {...rest}>
+      {children}
+    </div>
+  )
+})
+
+Hint.displayName = 'Hint'

--- a/src/react/hint/index.ts
+++ b/src/react/hint/index.ts
@@ -1,0 +1,1 @@
+export * from './Hint'

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -2,8 +2,12 @@
 
 export * from './accordion'
 export * from './back-link/BackLink'
+export * from './error-message'
 export * from './footer'
 export * from './header'
+export * from './hint'
+export * from './input'
+export * from './label'
 export * from './MODUKBody/MODUKBody'
 export * from './phase-banner'
 export * from './table'

--- a/src/react/input/Input.tsx
+++ b/src/react/input/Input.tsx
@@ -1,0 +1,106 @@
+import clsx from 'clsx'
+import { type ComponentPropsWithoutRef, forwardRef, type ReactElement, type ReactNode, useId } from 'react'
+import { type ErrorMessageProps } from '../error-message'
+import { type HintProps } from '../hint'
+import { FormGroup } from '../internal/FormGroup'
+import { type LabelProps } from '../label'
+import { type InputPrefixProps } from './InputPrefix'
+import { type InputSuffixProps } from './InputSuffix'
+
+export interface InputProps extends Omit<ComponentPropsWithoutRef<'input'>, 'children' | 'prefix'> {
+  /**
+   * Optional error message. This should be an instance of ErrorMessage.
+   */
+  errorMessage?: ReactElement<ErrorMessageProps>
+  /**
+   * Classes to add to the form group (for example to show error state for the whole group).
+   */
+  formGroupClassName?: string
+  /**
+   * Optional hint. This should be an instance of Hint.
+   */
+  hint?: ReactElement<HintProps>
+  /**
+   * Label for the input. This should be an instance of Label.
+   */
+  label: ReactElement<LabelProps>
+  /**
+   * Optional prefix to display before the input. This should be an instance of InputPrefix.
+   */
+  prefix?: ReactElement<InputPrefixProps>
+  /**
+   * Optional suffix to display after the input. This should be an instance of InputSuffix.
+   */
+  suffix?: ReactElement<InputSuffixProps>
+}
+
+function InputWrapper({ children, hasPrefixOrSuffix }: { children: ReactNode; hasPrefixOrSuffix: boolean }) {
+  if (hasPrefixOrSuffix) {
+    return <div className='govuk-input__wrapper'>{children}</div>
+  }
+
+  return <>{children}</>
+}
+
+/**
+ * Text input.
+ *
+ * @experimental React components are in alpha and subject to change.
+ *
+ * @example
+ * <Input
+ *   hint={<Hint>The name you’ll use on promotional material</Hint>}
+ *   label={
+ *     <Label className='govuk-label--l' isPageHeading>
+ *       What is the name of the event?
+ *     </Label>
+ *   }
+ *   name='event-name-with-hint'
+ * />
+ */
+export const Input = forwardRef<HTMLInputElement, InputProps>((
+  {
+    'aria-describedby': ariaDescribedBy,
+    className,
+    errorMessage,
+    formGroupClassName,
+    hint,
+    id,
+    label,
+    prefix,
+    suffix,
+    type = 'text',
+    ...rest
+  },
+  ref,
+) => {
+  const autoId = useId()
+  const resolvedId = id || autoId
+  const resolvedAriaDescribedBy = [
+    ariaDescribedBy ?? [],
+    errorMessage ? `${resolvedId}-error` : [],
+    hint ? `${resolvedId}-hint` : [],
+  ].flat().join(' ')
+
+  return (
+    <FormGroup className={clsx(errorMessage && 'govuk-form-group--error', formGroupClassName)} id={resolvedId}>
+      {label}
+      {hint}
+      {errorMessage}
+      <InputWrapper hasPrefixOrSuffix={Boolean(prefix || suffix)}>
+        {prefix}
+        <input
+          ref={ref}
+          aria-describedby={resolvedAriaDescribedBy}
+          className={clsx('govuk-input', errorMessage && 'govuk-input--error', className)}
+          id={resolvedId}
+          type={type}
+          {...rest}
+        />
+        {suffix}
+      </InputWrapper>
+    </FormGroup>
+  )
+})
+
+Input.displayName = 'Input'

--- a/src/react/input/InputPrefix.tsx
+++ b/src/react/input/InputPrefix.tsx
@@ -1,0 +1,15 @@
+import clsx from 'clsx'
+import { type ComponentPropsWithoutRef, forwardRef, type ReactNode } from 'react'
+
+export interface InputPrefixProps extends ComponentPropsWithoutRef<'div'> {
+  children: ReactNode
+}
+
+/**
+ * @experimental React components are in alpha and subject to change.
+ */
+export const InputPrefix = forwardRef<HTMLDivElement, InputPrefixProps>(({ children, className }, ref) => (
+  <div ref={ref} className={clsx('govuk-input__prefix', className)} aria-hidden='true'>{children}</div>
+))
+
+InputPrefix.displayName = 'InputPrefix'

--- a/src/react/input/InputSuffix.tsx
+++ b/src/react/input/InputSuffix.tsx
@@ -1,0 +1,15 @@
+import clsx from 'clsx'
+import { type ComponentPropsWithoutRef, forwardRef, type ReactNode } from 'react'
+
+/**
+ * @experimental React components are in alpha and subject to change.
+ */
+export interface InputSuffixProps extends ComponentPropsWithoutRef<'div'> {
+  children: ReactNode
+}
+
+export const InputSuffix = forwardRef<HTMLDivElement, InputSuffixProps>(({ children, className }, ref) => (
+  <div ref={ref} className={clsx('govuk-input__suffix', className)} aria-hidden='true'>{children}</div>
+))
+
+InputSuffix.displayName = 'InputSuffix'

--- a/src/react/input/__examples__/default.tsx
+++ b/src/react/input/__examples__/default.tsx
@@ -1,0 +1,12 @@
+import { Input, Label } from '@moduk/frontend/react'
+
+export const Example = () => (
+  <Input
+    label={
+      <Label className='govuk-label--l' isPageHeading>
+        What is the name of the event?
+      </Label>
+    }
+    name='event-name-default'
+  />
+)

--- a/src/react/input/__examples__/not-as-page-heading.tsx
+++ b/src/react/input/__examples__/not-as-page-heading.tsx
@@ -1,0 +1,8 @@
+import { Input, Label } from '@moduk/frontend/react'
+
+export const Example = () => (
+  <Input
+    label={<Label>What is the name of the event?</Label>}
+    name='event-name-with-not-as-page-heading'
+  />
+)

--- a/src/react/input/__examples__/with-error.tsx
+++ b/src/react/input/__examples__/with-error.tsx
@@ -1,0 +1,14 @@
+import { ErrorMessage, Hint, Input, Label } from '@moduk/frontend/react'
+
+export const Example = () => (
+  <Input
+    errorMessage={<ErrorMessage>Enter an event name</ErrorMessage>}
+    hint={<Hint>The name you’ll use on promotional material</Hint>}
+    label={
+      <Label className='govuk-label--l' isPageHeading>
+        What is the name of the event?
+      </Label>
+    }
+    name='event-name-with-error'
+  />
+)

--- a/src/react/input/__examples__/with-fixed-width.tsx
+++ b/src/react/input/__examples__/with-fixed-width.tsx
@@ -1,0 +1,36 @@
+import { Input, Label } from '@moduk/frontend/react'
+
+export const Example = () => (
+  <div>
+    <Input
+      className='govuk-input--width-20'
+      label={<Label>20 character width</Label>}
+      name='width-20'
+    />
+    <Input
+      className='govuk-input--width-10'
+      label={<Label>10 character width</Label>}
+      name='width-10'
+    />
+    <Input
+      className='govuk-input--width-5'
+      label={<Label>5 character width</Label>}
+      name='width-5'
+    />
+    <Input
+      className='govuk-input--width-4'
+      label={<Label>4 character width</Label>}
+      name='width-4'
+    />
+    <Input
+      className='govuk-input--width-3'
+      label={<Label>3 character width</Label>}
+      name='width-3'
+    />
+    <Input
+      className='govuk-input--width-2'
+      label={<Label>2 character width</Label>}
+      name='width-2'
+    />
+  </div>
+)

--- a/src/react/input/__examples__/with-fluid-width.tsx
+++ b/src/react/input/__examples__/with-fluid-width.tsx
@@ -1,0 +1,36 @@
+import { Input, Label } from '@moduk/frontend/react'
+
+export const Example = () => (
+  <div>
+    <Input
+      className='govuk-!-width-full'
+      label={<Label>Full width</Label>}
+      name='full'
+    />
+    <Input
+      className='govuk-!-width-three-quarters'
+      label={<Label>Three-quarters width</Label>}
+      name='three-quarters'
+    />
+    <Input
+      className='govuk-!-width-two-thirds'
+      label={<Label>Two-thirds width</Label>}
+      name='two-thirds'
+    />
+    <Input
+      className='govuk-!-width-one-half'
+      label={<Label>One-half width</Label>}
+      name='one-half'
+    />
+    <Input
+      className='govuk-!-width-one-third'
+      label={<Label>One-third width</Label>}
+      name='one-third'
+    />
+    <Input
+      className='govuk-!-width-one-quarter'
+      label={<Label>One-quarter width</Label>}
+      name='one-quarter'
+    />
+  </div>
+)

--- a/src/react/input/__examples__/with-hint.tsx
+++ b/src/react/input/__examples__/with-hint.tsx
@@ -1,0 +1,13 @@
+import { Hint, Input, Label } from '@moduk/frontend/react'
+
+export const Example = () => (
+  <Input
+    hint={<Hint>The name you’ll use on promotional material</Hint>}
+    label={
+      <Label className='govuk-label--l' isPageHeading>
+        What is the name of the event?
+      </Label>
+    }
+    name='event-name-with-hint'
+  />
+)

--- a/src/react/input/__examples__/with-numeric.tsx
+++ b/src/react/input/__examples__/with-numeric.tsx
@@ -1,0 +1,16 @@
+import { Hint, Input, Label } from '@moduk/frontend/react'
+
+export const Example = () => (
+  <Input
+    className='govuk-input--width-10'
+    hint={<Hint>Must be between 6 and 8 digits long</Hint>}
+    inputMode='numeric'
+    label={
+      <Label className='govuk-label--l' isPageHeading>
+        What is your account number?
+      </Label>
+    }
+    name='account-number-with-numeric'
+    spellCheck={false}
+  />
+)

--- a/src/react/input/__examples__/with-prefix-and-suffix-error.tsx
+++ b/src/react/input/__examples__/with-prefix-and-suffix-error.tsx
@@ -1,0 +1,17 @@
+import { ErrorMessage, Input, InputPrefix, InputSuffix, Label } from '@moduk/frontend/react'
+
+export const Example = () => (
+  <Input
+    className='govuk-input--width-5'
+    errorMessage={<ErrorMessage>Enter a cost per item, in pounds</ErrorMessage>}
+    label={
+      <Label className='govuk-label--l' isPageHeading>
+        What is the cost per item, in pounds?
+      </Label>
+    }
+    name='cost-per-item-with-prefix-and-suffix-error'
+    prefix={<InputPrefix>£</InputPrefix>}
+    suffix={<InputSuffix>per item</InputSuffix>}
+    spellCheck={false}
+  />
+)

--- a/src/react/input/__examples__/with-prefix-and-suffix.tsx
+++ b/src/react/input/__examples__/with-prefix-and-suffix.tsx
@@ -1,0 +1,16 @@
+import { Input, InputPrefix, InputSuffix, Label } from '@moduk/frontend/react'
+
+export const Example = () => (
+  <Input
+    className='govuk-input--width-5'
+    label={
+      <Label className='govuk-label--l' isPageHeading>
+        What is the cost per item, in pounds?
+      </Label>
+    }
+    name='cost-per-item-with-prefix-and-suffix'
+    prefix={<InputPrefix>£</InputPrefix>}
+    suffix={<InputSuffix>per item</InputSuffix>}
+    spellCheck={false}
+  />
+)

--- a/src/react/input/__examples__/with-prefix.tsx
+++ b/src/react/input/__examples__/with-prefix.tsx
@@ -1,0 +1,15 @@
+import { Input, InputPrefix, Label } from '@moduk/frontend/react'
+
+export const Example = () => (
+  <Input
+    className='govuk-input--width-5'
+    label={
+      <Label className='govuk-label--l' isPageHeading>
+        What is the cost in pounds?
+      </Label>
+    }
+    name='cost-with-prefix'
+    prefix={<InputPrefix>£</InputPrefix>}
+    spellCheck={false}
+  />
+)

--- a/src/react/input/__examples__/with-suffix.tsx
+++ b/src/react/input/__examples__/with-suffix.tsx
@@ -1,0 +1,15 @@
+import { Input, InputSuffix, Label } from '@moduk/frontend/react'
+
+export const Example = () => (
+  <Input
+    className='govuk-input--width-5'
+    label={
+      <Label className='govuk-label--l' isPageHeading>
+        What is the weight in kilograms?
+      </Label>
+    }
+    name='weight-with-suffix'
+    suffix={<InputSuffix>kg</InputSuffix>}
+    spellCheck={false}
+  />
+)

--- a/src/react/input/__tests__/Input.test.tsx
+++ b/src/react/input/__tests__/Input.test.tsx
@@ -1,0 +1,150 @@
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useRef, useState } from 'react'
+import { describe, expect, test } from 'vitest'
+import { ErrorMessage, Hint, Input, Label } from '../..'
+
+describe('Input', () => {
+  test('sets custom form group classes', () => {
+    const { container } = render(
+      <Input
+        formGroupClassName='form-group-class-name'
+        label={
+          <Label className='govuk-label--l' isPageHeading>
+            What is the name of the event?
+          </Label>
+        }
+        name='event-name-default'
+      />,
+    )
+
+    expect(container.querySelector('.govuk-form-group')).toHaveClass('form-group-class-name')
+  })
+
+  test('generates ids automatically', () => {
+    const { container, getByRole, getByText } = render(
+      <Input
+        errorMessage={<ErrorMessage>Enter an event name</ErrorMessage>}
+        hint={<Hint>The name you’ll use on promotional material</Hint>}
+        id='explicit-id'
+        label={
+          <Label className='govuk-label--l' isPageHeading>
+            What is the name of the event?
+          </Label>
+        }
+        name='event-name-with-error'
+      />,
+    )
+
+    const input = getByRole('textbox')
+
+    expect(input.id).toBeTruthy()
+    expect(container.querySelector('.govuk-label')).toHaveAttribute('id', `${input.id}-label`)
+    expect(getByText('The name you’ll use on promotional material')).toHaveAttribute('id', `${input.id}-hint`)
+    expect(getByText('Enter an event name')).toHaveAttribute('id', `${input.id}-error`)
+  })
+
+  test('uses an explicitly set id', () => {
+    const { container, getByRole, getByText } = render(
+      <Input
+        errorMessage={<ErrorMessage>Enter an event name</ErrorMessage>}
+        hint={<Hint>The name you’ll use on promotional material</Hint>}
+        id='explicit-id'
+        label={
+          <Label className='govuk-label--l' isPageHeading>
+            What is the name of the event?
+          </Label>
+        }
+        name='event-name-with-error'
+      />,
+    )
+
+    expect(getByRole('textbox')).toHaveAttribute('id', 'explicit-id')
+    expect(container.querySelector('.govuk-label')).toHaveAttribute('id', 'explicit-id-label')
+    expect(getByText('The name you’ll use on promotional material')).toHaveAttribute('id', 'explicit-id-hint')
+    expect(getByText('Enter an event name')).toHaveAttribute('id', 'explicit-id-error')
+  })
+
+  test('can be controlled', async () => {
+    const Example = () => {
+      const [value, setValue] = useState('initial')
+
+      return (
+        <>
+          <div data-testid='value'>{value}</div>
+          <button
+            onClick={() => {
+              setValue('changed value')
+            }}
+          >
+            change value
+          </button>
+          <Input
+            label={<Label>name</Label>}
+            name='event-name-default'
+            onChange={(event) => {
+              setValue(event.currentTarget.value)
+            }}
+            value={value}
+          />
+        </>
+      )
+    }
+
+    const user = userEvent.setup()
+
+    const { getByLabelText, getByText, getByTestId } = render(<Example />)
+
+    const input = getByLabelText('name')
+    expect(input).toHaveValue('initial')
+
+    await user.clear(input)
+    await user.type(input, 'typed value')
+    expect(input).toHaveValue('typed value')
+    expect(getByTestId('value')).toHaveTextContent(/^typed value$/)
+
+    await user.click(getByText('change value'))
+    expect(input).toHaveValue('changed value')
+  })
+
+  test('can be uncontrolled', async () => {
+    const Example = () => {
+      const [value, setValue] = useState('initial')
+      const ref = useRef<HTMLInputElement>(null)
+
+      return (
+        <>
+          <div data-testid='value'>{value}</div>
+          <button
+            onClick={() => {
+              setValue(ref.current?.value ?? '')
+            }}
+          >
+            get value
+          </button>
+          <Input
+            ref={ref}
+            label={<Label>name</Label>}
+            name='event-name-default'
+            defaultValue={value}
+          />
+        </>
+      )
+    }
+
+    const user = userEvent.setup()
+
+    const { getByLabelText, getByText, getByTestId } = render(<Example />)
+
+    const input = getByLabelText('name')
+    expect(input).toHaveValue('initial')
+
+    await user.clear(input)
+    await user.type(input, 'typed value')
+    expect(input).toHaveValue('typed value')
+    expect(getByTestId('value')).toHaveTextContent(/^initial$/)
+
+    await user.click(getByText('get value'))
+    expect(getByTestId('value')).toHaveTextContent(/^typed value$/)
+  })
+})

--- a/src/react/input/index.ts
+++ b/src/react/input/index.ts
@@ -1,0 +1,3 @@
+export * from './Input'
+export * from './InputPrefix'
+export * from './InputSuffix'

--- a/src/react/internal/FormGroup/FormGroup.tsx
+++ b/src/react/internal/FormGroup/FormGroup.tsx
@@ -1,0 +1,19 @@
+import clsx from 'clsx'
+import { type ReactNode, useMemo } from 'react'
+import { FormGroupContext } from './FormGroupContext'
+
+interface FormGroupProps {
+  children: ReactNode
+  className: string
+  id: string
+}
+
+export function FormGroup({ children, className, id }: FormGroupProps) {
+  const contextValue = useMemo(() => ({ id }), [id])
+
+  return (
+    <FormGroupContext.Provider value={contextValue}>
+      <div className={clsx('govuk-form-group', className)}>{children}</div>
+    </FormGroupContext.Provider>
+  )
+}

--- a/src/react/internal/FormGroup/FormGroupContext.tsx
+++ b/src/react/internal/FormGroup/FormGroupContext.tsx
@@ -1,0 +1,7 @@
+import { createContext } from 'react'
+
+export interface FormGroupContextProps {
+  id: string
+}
+
+export const FormGroupContext = createContext<FormGroupContextProps>({ id: '' })

--- a/src/react/internal/FormGroup/index.ts
+++ b/src/react/internal/FormGroup/index.ts
@@ -1,0 +1,2 @@
+export * from './FormGroup'
+export * from './FormGroupContext'

--- a/src/react/label/Label.tsx
+++ b/src/react/label/Label.tsx
@@ -1,0 +1,42 @@
+import clsx from 'clsx'
+import { type ComponentPropsWithoutRef, forwardRef, type ReactNode, useContext } from 'react'
+import { FormGroupContext } from '../internal/FormGroup'
+
+export interface LabelProps extends ComponentPropsWithoutRef<'label'> {
+  children: ReactNode
+  /**
+   * Whether the label also acts as the heading for the page.
+   */
+  isPageHeading?: boolean
+}
+
+/**
+ * Label for a form element.
+ *
+ * @experimental React components are in alpha and subject to change.
+ */
+export const Label = forwardRef<HTMLLabelElement, LabelProps>(
+  ({ children, className, htmlFor, id, isPageHeading, ...rest }, ref) => {
+    const context = useContext(FormGroupContext)
+
+    const label = (
+      <label
+        ref={ref}
+        className={clsx('govuk-label', className)}
+        htmlFor={context.id || htmlFor}
+        id={context.id ? `${context.id}-label` : id}
+        {...rest}
+      >
+        {children}
+      </label>
+    )
+
+    if (isPageHeading) {
+      return <h1 className='govuk-label-wrapper'>{label}</h1>
+    }
+
+    return label
+  },
+)
+
+Label.displayName = 'Label'

--- a/src/react/label/index.ts
+++ b/src/react/label/index.ts
@@ -1,0 +1,1 @@
+export * from './Label'


### PR DESCRIPTION
This adds a React implementation of the text input component, including the supplementary components (error message, hint, label etc).

Similar to some other components, instances of those supplementary components are passed as props. This allows customisation of them in a clear way (and still using JSX), while still giving the root component some control and awareness of them.

The `id` for the `<input>` and related elements are automatically generated using `useId()` if an `id` is not explicitly specified. The `id` is passed to child components using a context so that it doesn't need to be repeated or passed around in awkward ways.