### PR TITLE
fix(accordion): Fix ID generation of nested items in React component

### DIFF
--- a/src/react/accordion/Accordion.tsx
+++ b/src/react/accordion/Accordion.tsx
@@ -2,7 +2,7 @@
 
 import clsx from 'clsx'
 import { isEqual, pick } from 'lodash'
-import { Children, type ComponentPropsWithoutRef, forwardRef, isValidElement, useMemo, useRef } from 'react'
+import { type ComponentPropsWithoutRef, forwardRef, isValidElement, useMemo, useRef } from 'react'
 import flattenChildren from 'react-keyed-flatten-children'
 
 import { mergeRefs } from 'react-merge-refs'
@@ -150,6 +150,8 @@ export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
       'data-i18n.show-section-aria-label': showSectionAriaLabelText,
     }
 
+    const flattenedChildren = flattenChildren(children).filter(isValidElement)
+
     return (
       <AccordionContext.Provider value={contextValue}>
         <div
@@ -162,10 +164,11 @@ export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
           id={id}
           {...i18nAttributes}
         >
-          {Children.map(
-            children,
+          {flattenedChildren.map(
             (child, index) => (
-              <AccordionItemIndexContext.Provider value={index}>{child}</AccordionItemIndexContext.Provider>
+              <AccordionItemIndexContext.Provider key={child.key} value={index}>
+                {child}
+              </AccordionItemIndexContext.Provider>
             ),
           )}
         </div>

--- a/src/react/accordion/__tests__/Accordion.test.tsx
+++ b/src/react/accordion/__tests__/Accordion.test.tsx
@@ -157,4 +157,24 @@ describe('Accordion', () => {
     expect(queryByText('This is the content for Writing well for the web.')).not.toBeInTheDocument()
     expect(getByText('Updated text.')).toBeInTheDocument()
   })
+
+  test('generates correct IDs for items nested in a fragment', async () => {
+    const { getByText } = render(
+      <Accordion id='accordion-default'>
+        <AccordionItem heading='Writing well for the web'>
+          <p className='govuk-body'>This is the content for Writing well for the web.</p>
+        </AccordionItem>
+        <>
+          <AccordionItem heading='Writing well for specialists'>
+            <p className='govuk-body'>This is the content for Writing well for specialists.</p>
+          </AccordionItem>
+          <AccordionItem heading='Know your audience'>
+            <p className='govuk-body'>This is the content for Know your audience.</p>
+          </AccordionItem>
+        </>
+      </Accordion>,
+    )
+
+    expect(getByText('Know your audience')).toHaveAttribute('id', 'accordion-default-heading-3')
+  })
 })


### PR DESCRIPTION
IDs for accordion items nested in a fragment weren't generated correctly, as those items weren't encountered when mapping over the accordion's children. This flattens the accordion's children before rendering to avoid that problem.