### PR TITLE
docs: Add missing docs to React components

### DIFF
--- a/src/react/MODUKBody/MODUKBody.tsx
+++ b/src/react/MODUKBody/MODUKBody.tsx
@@ -4,6 +4,13 @@ import clsx from 'clsx'
 import { type ComponentPropsWithoutRef, useEffect, useState } from 'react'
 
 /**
+ * Replacement for <body> tag when using React to render the
+ * entire page.
+ *
+ * This handles adding the `js-enabled` CSS class to the body
+ * element when JavaScript is available, ensuring interactive
+ * components are styled correctly.
+ *
  * @experimental React components are in alpha and subject to change.
  */
 export const MODUKBody = ({ children, className, ...rest }: ComponentPropsWithoutRef<'body'>) => {

--- a/src/react/accordion/Accordion.tsx
+++ b/src/react/accordion/Accordion.tsx
@@ -15,15 +15,62 @@ import type { AccordionItemProps } from './AccordionItem'
 import { AccordionItemIndexContext } from './AccordionItemIndexContext'
 
 export interface AccordionProps extends ComponentPropsWithoutRef<'div'> {
+  /**
+   * Instances of AccordionItem.
+   */
   children: PermissiveChild<AccordionItemProps>
+  /**
+   * HTML tag to use for item headings.
+   */
   headingTag?: AccordionHeadingTag
+  /**
+   * The text content of the 'Hide all sections' button at
+   * the top of the accordion when all sections are expanded.
+   */
   hideAllSectionsText?: string
+  /**
+   * The text content of the 'Hide' button within each section
+   * of the accordion, which is visible when the section is
+   * expanded.
+   */
   hideSectionText?: string
+  /**
+   * Text made available to assistive technologies, like
+   * screen readers, as the final part of the toggle's
+   * accessible name when the section is expanded. Defaults
+   * to 'Hide this section'.
+   */
   hideSectionAriaLabelText?: string
+  /**
+   * Unique identifier for the accordion.
+   *
+   * Must be unique across the domain of your service if
+   * rememberExpanded is set.
+   */
   id: string
+  /**
+   * Whether the expanded/collapsed state of the accordion
+   * should be saved when a user leaves the page and restored
+   * when they return. Default is true.
+   */
   rememberExpanded?: boolean
+  /**
+   * The text content of the 'Show all sections' button at the
+   * top of the accordion when at least one section is collapsed.
+   */
   showAllSectionsText?: string
+  /**
+   * Text made available to assistive technologies, like screen
+   * readers, as the final part of the toggle's accessible name
+   * when the section is collapsed. Defaults to 'Show this
+   * section'.
+   */
   showSectionAriaLabelText?: string
+  /**
+   * The text content of the 'Show' button within each section
+   * of the accordion, which is visible when the section is
+   * collapsed.
+   */
   showSectionText?: string
 }
 
@@ -46,7 +93,25 @@ function getRemountProps(props: AccordionProps) {
 }
 
 /**
+ * Accordion.
+ *
  * @experimental React components are in alpha and subject to change.
+ *
+ * @example
+ * <Accordion id='example-accordion'>
+ *   <AccordionItem heading='Writing well for the web'>
+ *     <p className='govuk-body'>This is the content for Writing well for the web.</p>
+ *   </AccordionItem>
+ *   <AccordionItem heading='Writing well for specialists'>
+ *     <p className='govuk-body'>This is the content for Writing well for specialists.</p>
+ *   </AccordionItem>
+ *   <AccordionItem heading='Know your audience'>
+ *     <p className='govuk-body'>This is the content for Know your audience.</p>
+ *   </AccordionItem>
+ *   <AccordionItem heading='How people read'>
+ *     <p className='govuk-body'>This is the content for How people read.</p>
+ *   </AccordionItem>
+ * </Accordion>
  */
 export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
   (props, forwardedRef) => {

--- a/src/react/accordion/AccordionItem.tsx
+++ b/src/react/accordion/AccordionItem.tsx
@@ -6,13 +6,27 @@ import { AccordionContext } from './AccordionContext'
 import { AccordionItemIndexContext } from './AccordionItemIndexContext'
 
 export interface AccordionItemProps {
+  /**
+   * Content for the section.
+   */
   children: Exclude<ReactNode, ReactPortal | null | undefined>
+  /**
+   * Whether this section is expanded.
+   */
   expanded?: boolean
+  /**
+   * Heading for the section.
+   */
   heading: Exclude<ReactNode, ReactPortal | null | undefined>
+  /**
+   * Summary line content.
+   */
   summary?: Exclude<ReactNode, ReactPortal>
 }
 
 /**
+ * An accordion section.
+ *
  * @experimental React components are in alpha and subject to change.
  */
 export function AccordionItem({

--- a/src/react/back-link/BackLink.tsx
+++ b/src/react/back-link/BackLink.tsx
@@ -9,7 +9,15 @@ interface BackLinkProps {
 }
 
 /**
+ * A back link.
+ *
  * @experimental React components are in alpha and subject to change.
+ *
+ * @example
+ * <BackLink href='/previous-page'>Back</BackLink>
+ *
+ * @example
+ * <BackLink component={Link} to='/previous-page'>Back</BackLink>
  */
 export const BackLink: LinkComponent<BackLinkProps> = forwardRef<HTMLAnchorElement, BackLinkProps>((
   { children, className, ...props },

--- a/src/react/header/Header.tsx
+++ b/src/react/header/Header.tsx
@@ -6,12 +6,40 @@ import MODUKHeaderLogo from '../../assets/svg/moduk-header-logo.svg'
 import { useMODUKComponent } from '../internal/hooks/useMODUKComponent'
 
 interface HeaderContentProps {
+  /**
+   * The name of your service, included in the header.
+   */
   serviceName?: string
+  /**
+   * URL for the service name anchor.
+   */
   serviceUrl?: string
+  /**
+   * Text for the aria-label attribute of the button that
+   * opens the mobile navigation, if there is a mobile
+   * navigation menu. Defaults to 'Show or hide menu'.
+   */
   menuButtonLabel?: string
+  /**
+   * Text of the button that opens the mobile navigation
+   * menu, if there is a mobile navigation menu. There is
+   * no enforced character limit, but there is a limited
+   * display space so keep text as short as possible. By
+   * default, this is set to 'Menu'.
+   */
   menuButtonText?: string
+  /**
+   * Optional instances of HeaderNavigationItem.
+   */
   children?: ReactNode
+  /**
+   * CSS classes for the navigation section of the header.
+   */
   navigationClassName?: string
+  /**
+   * Text for the aria-label attribute of the navigation.
+   * Defaults to the same value as menuButtonText.
+   */
   navigationLabel?: string
 }
 
@@ -74,7 +102,32 @@ function HeaderContent(props: HeaderContentProps) {
 }
 
 /**
+ * Header.
+ *
  * @experimental React components are in alpha and subject to change.
+ *
+ * @example
+ * <Header homepageUrl='#' serviceName='Service name' serviceUrl='#' />
+ *
+ * @example
+ * <Header
+ *   homepageUrl='#'
+ *   serviceName='Service name'
+ *   serviceUrl='#'
+ * >
+ *   <HeaderNavigationItem active>
+ *     <HeaderNavigationLink href='#1'>Navigation item 1</HeaderNavigationLink>
+ *   </HeaderNavigationItem>
+ *   <HeaderNavigationItem>
+ *     <HeaderNavigationLink href='#2'>Navigation item 2</HeaderNavigationLink>
+ *   </HeaderNavigationItem>
+ *   <HeaderNavigationItem>
+ *     <HeaderNavigationLink href='#3'>Navigation item 3</HeaderNavigationLink>
+ *   </HeaderNavigationItem>
+ *   <HeaderNavigationItem>
+ *     <HeaderNavigationLink href='#4'>Navigation item 4</HeaderNavigationLink>
+ *   </HeaderNavigationItem>
+ * </Header>
  */
 export const Header = forwardRef<HTMLElement, HeaderProps>((props, forwardedRef) => {
   const { ref } = useMODUKComponent('Header')

--- a/src/react/header/HeaderNavigationItem.tsx
+++ b/src/react/header/HeaderNavigationItem.tsx
@@ -2,12 +2,20 @@ import clsx from 'clsx'
 import { forwardRef, type ReactNode } from 'react'
 
 export interface HeaderNavigationItemProps {
+  /**
+   * An instance of HeaderNavigationLink.
+   */
   children: ReactNode
   className?: string
+  /**
+   * Whether this navigation item is active.
+   */
   active?: boolean
 }
 
 /**
+ * A header navigation item.
+ *
  * @experimental React components are in alpha and subject to change.
  */
 export const HeaderNavigationItem = forwardRef<

--- a/src/react/header/HeaderNavigationLink.tsx
+++ b/src/react/header/HeaderNavigationLink.tsx
@@ -8,6 +8,8 @@ export interface HeaderNavigationLinkProps {
 }
 
 /**
+ * A link within a header navigation item.
+ *
  * @experimental React components are in alpha and subject to change.
  */
 export const HeaderNavigationLink: LinkComponent<HeaderNavigationLinkProps> = forwardRef<

--- a/src/react/internal/Link/Link.tsx
+++ b/src/react/internal/Link/Link.tsx
@@ -8,6 +8,12 @@ import {
 } from 'react'
 
 type LinkProps<T extends ElementType> = {
+  /**
+   * The component to use for links (for example, a Link component
+   * from a routing library).
+   *
+   * Defaults to an anchor tag.
+   */
   component?: T
 } & ComponentPropsWithoutRef<T>
 


### PR DESCRIPTION
Some components were missing doc comments. This adds them.