### PR TITLE
feat(details): Add React implementation

### DIFF
--- a/src/react/details/Details.tsx
+++ b/src/react/details/Details.tsx
@@ -1,0 +1,40 @@
+import clsx from 'clsx'
+import { type ComponentPropsWithoutRef, forwardRef, type ReactNode } from 'react'
+
+export interface DetailsProps extends ComponentPropsWithoutRef<'details'> {
+  /**
+   * Content to be displayed when the details element is expanded.
+   */
+  children: ReactNode
+  /**
+   * Content for the summary element.
+   */
+  summary: ReactNode
+}
+
+/**
+ * Details component.
+ *
+ * @experimental React components are in alpha and subject to change.
+ *
+ * @example
+ * <Details summary='Help with organisation'>
+ *   We need to know the organisation you work for so we can forward your request to the correct team.
+ * </Details>
+ */
+export const Details = forwardRef<HTMLDetailsElement, DetailsProps>(
+  ({ children, className, summary, ...rest }, ref) => (
+    <details ref={ref} className={clsx('govuk-details', className)} {...rest}>
+      <summary className='govuk-details__summary'>
+        <span className='govuk-details__summary-text'>
+          {summary}
+        </span>
+      </summary>
+      <div className='govuk-details__text'>
+        {children}
+      </div>
+    </details>
+  ),
+)
+
+Details.displayName = 'Details'

--- a/src/react/details/__examples__/default.tsx
+++ b/src/react/details/__examples__/default.tsx
@@ -1,0 +1,7 @@
+import { Details } from '@moduk/frontend/react'
+
+export const Example = () => (
+  <Details summary='Help with organisation'>
+    We need to know the organisation you work for so we can forward your request to the correct team.
+  </Details>
+)

--- a/src/react/details/__examples__/open.tsx
+++ b/src/react/details/__examples__/open.tsx
@@ -1,0 +1,7 @@
+import { Details } from '@moduk/frontend/react'
+
+export const Example = () => (
+  <Details summary='Help with organisation' open>
+    We need to know the organisation you work for so we can forward your request to the correct team.
+  </Details>
+)

--- a/src/react/details/index.ts
+++ b/src/react/details/index.ts
@@ -1,0 +1,1 @@
+export * from './Details'

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -2,6 +2,7 @@
 
 export * from './accordion'
 export * from './back-link/BackLink'
+export * from './details'
 export * from './error-message'
 export * from './footer'
 export * from './header'


### PR DESCRIPTION
This adds a React implementation of the details component.

The GOV.UK JavaScript for this component is a ponyfill for IE. It is not loaded as React 18 does not work with IE (the JavaScript has also been removed for GOV.UK Frontend 5.0.0).