### PR TITLE
ci: Run fixup workflow on release branches

### DIFF
--- a/.github/workflows/check-fixups.yml
+++ b/.github/workflows/check-fixups.yml
@@ -2,6 +2,9 @@ name: Check for fixup! commits
 
 on:
   pull_request:
+  push:
+    branches:
+      - release-bot/**
 
 jobs:
   check-for-fixup-commits:


### PR DESCRIPTION
Since 'Check for fixup! commits' is a required check, the workflow needs to run on release branches even if the job is skipped.