### PR TITLE
refactor: Remove duplicate PermissiveChild definition

### DIFF
--- a/src/react/internal/PermissiveChild.tsx
+++ b/src/react/internal/PermissiveChild.tsx
@@ -1,3 +1,0 @@
-import type { ReactElement } from 'react'
-
-export type PermissiveChild<Props = unknown> = ReactElement<Props> | boolean | null | Iterable<PermissiveChild<Props>>


### PR DESCRIPTION
`PermissiveChild` was defined twice, once in `src/react/internal/PermissiveChild.ts` and once in `src/react/internal/PermissiveChild.tsx`. This removes the latter.