### PR TITLE
chore: Change hydration root on React example pages

### DIFF
--- a/examples-site/react/example-client.tsx
+++ b/examples-site/react/example-client.tsx
@@ -49,7 +49,7 @@ const getComponent = async (): Promise<ComponentType> => {
     const Component = await getComponent()
 
     hydrateRoot(
-      document,
+      document.documentElement,
       <StrictMode>
         <Root exampleName={exampleName} component={component}>
           <Component />
@@ -66,7 +66,7 @@ const getComponent = async (): Promise<ComponentType> => {
     )
   } catch (err) {
     hydrateRoot(
-      document,
+      document.documentElement,
       <StrictMode>
         <Root>
           <div>{err instanceof Error ? err.message : 'Unexpected Error'}</div>

--- a/examples-site/react/example.njk
+++ b/examples-site/react/example.njk
@@ -7,4 +7,6 @@ permalink: 'react/components/{{ example.component }}/{{ example.exampleName }}/i
 ---
 <!DOCTYPE html>
 
+<html lang='en'>
 {% react example %}
+</html>

--- a/src/react/internal/test-utils/Root.tsx
+++ b/src/react/internal/test-utils/Root.tsx
@@ -8,7 +8,7 @@ interface RootProps {
 export const Root = ({ exampleName, component, children }: PropsWithChildren<RootProps>) => {
   const titlePrefix = exampleName && component ? `${exampleName} – ${component} – ` : ''
   return (
-    <html lang='en'>
+    <>
       <head>
         <title>{`${titlePrefix}MOD.UK Frontend React`}</title>
         <meta name='viewport' content='width=device-width, initial-scale=1, viewport-fit=cover' />
@@ -21,6 +21,6 @@ export const Root = ({ exampleName, component, children }: PropsWithChildren<Roo
         </div>
         <script src='/react-example-client/index.js'></script>
       </MODUKBody>
-    </html>
+    </>
   )
 }


### PR DESCRIPTION
This makes pages for React examples on the examples site hydrate the html element instead of the entire document.

This seems to resolve some intermittent hydration problems in WebKit on GitHub Actions.