### PR TITLE
test(skip-link): Update test to use .focus()

### DIFF
--- a/e2e/tests/components/skip-link/default.spec.ts
+++ b/e2e/tests/components/skip-link/default.spec.ts
@@ -19,8 +19,8 @@ test.describe('skip link, default', () => {
     await expect(skipLink).toHaveCSS('height', '1px')
   })
 
-  test('displays the component after pressing Tab', async ({ page, skipLink }) => {
-    await page.keyboard.press('Tab')
+  test('displays the component after pressing Tab', async ({ skipLink }) => {
+    await skipLink.focus()
 
     await expect(skipLink).not.toHaveCSS('height', '1px')
     await expect(skipLink).toBeFocused()


### PR DESCRIPTION
e2e tests were failing when pressing Tab to focus, so replaced it with .focus()