### PR TITLE
deps(node): Remove node version limitation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "webpack-cli": "^5.1.4"
       },
       "engines": {
-        "node": "^16.13.0 || ^18.12.0",
+        "node": ">=18.12.0",
         "npm": ">=8.15.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "homepage": "https://github.com/defencedigital/moduk-frontend#readme",
   "engines": {
-    "node": ">=18.12.0",
+    "node": "^18.19.0 || ^20.11.0",
     "npm": ">=8.15.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "homepage": "https://github.com/defencedigital/moduk-frontend#readme",
   "engines": {
-    "node": "^16.13.0 || ^18.12.0",
+    "node": ">=18.12.0",
     "npm": ">=8.15.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Warning is shown when users use package with version of node that isn't 16 or 18. Removing this limitation so that all LTS versions can be used