### PR TITLE
deps(govuk-frontend): Update `govuk-frontend` to 4.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "npm": ">=8.15.0"
       },
       "peerDependencies": {
-        "govuk-frontend": "4.7.0",
+        "govuk-frontend": "4.8.0",
         "nunjucks": "^3.2.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -11081,9 +11081,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
-      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
+      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
       "peer": true,
       "engines": {
         "node": ">= 4.2.0"

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "optionator": "^0.9.3"
   },
   "peerDependencies": {
-    "govuk-frontend": "4.7.0",
+    "govuk-frontend": "4.8.0",
     "nunjucks": "^3.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
Users are locked into an old version of `govuk-frontend`