### PR TITLE
fix(govuk-frontend): Allow for compatible `govuk-frontend` versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "optionator": "^0.9.3"
   },
   "peerDependencies": {
-    "govuk-frontend": "5.0.0",
+    "govuk-frontend": "^5.0.0",
     "nunjucks": "^3.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
Allows the `govuk-frontend` peer dependency to be resolved when using versions other than 5.0.0 excatly