### PR TITLE
fix: make createNunjucksEnvironment function available

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
       "types": "./dist/lib/index.d.ts",
       "require": "./dist/lib/index.js",
       "sass": "./src/css/index.scss",
-      "style": "./dist/css/index.css"
+      "style": "./dist/css/index.css",
+      "default": "./dist/lib/index.js"
     },
     "./client": {
       "import": "./dist/client/moduk-frontend.mjs",


### PR DESCRIPTION
createNunjucksEnvironment was not being exported correctly