### PR TITLE
deps-dev(artifact-actions): Use v4 of `upload-artifact` and `download…

### DIFF
--- a/.github/actions/merge-playwright-reports/action.yml
+++ b/.github/actions/merge-playwright-reports/action.yml
@@ -11,17 +11,22 @@ runs:
   using: composite
   steps:
     - name: Download blob reports
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: ${{ inputs.input-artifact }}
+        merge-multiple: true
+        # v4 of upload-artifact does not allow uploading to the same artifact multiple times, so have to enumerate each artifact
+        # See https://github.com/actions/upload-artifact/issues/480
+        name: ${{ inputs.input-artifact }}-${{ strategy.job-index }}
         path: blob-reports
 
     - name: Merge reports
       shell: bash
       run: npm exec --no -- playwright merge-reports --reporter html blob-reports
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: ${{ inputs.output-artifact }}
+        # v4 of upload-artifact does not allow uploading to the same artifact multiple times, so have to enumerate each artifact
+        # See https://github.com/actions/upload-artifact/issues/480
+        name: ${{ inputs.output-artifact }}-${{ strategy.job-index }}
         path: playwright-report

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -104,10 +104,12 @@ jobs:
       - name: Run e2e tests
         run: npm run test:e2e -- --shard ${{ matrix.shard }}/${{ matrix.total_shards }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: e2e-blob-reports
+          # v4 of upload-artifact does not allow uploading to the same artifact multiple times, so have to enumerate each artifact
+          # See https://github.com/actions/upload-artifact/issues/480
+          name: e2e-blob-reports-${{ strategy.job-index }}
           path: blob-report
           retention-days: 1
 
@@ -153,10 +155,12 @@ jobs:
       - name: Run visual regression tests
         run: npm run test:visual:native -- --shard ${{ matrix.shard }}/${{ matrix.total_shards }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: visual-regression-blob-reports
+          # v4 of upload-artifact does not allow uploading to the same artifact multiple times, so have to enumerate each artifact
+          # See https://github.com/actions/upload-artifact/issues/480
+          name: visual-regression-blob-reports-${{ strategy.job-index }}
           path: blob-report
           retention-days: 1
 


### PR DESCRIPTION
…-artifact`

v3 of `actions/upload-artifact` and `actions/download-artifact` has been deprecated. This change updates GitHub workflows to use v4 instead.