### PR TITLE
fix: Fix flaky tests in CI

### DIFF
--- a/e2e/tests/visual-regression.spec.ts
+++ b/e2e/tests/visual-regression.spec.ts
@@ -8,6 +8,7 @@ test.describe('@visual-regression', () => {
         test.describe(exampleName, () => {
           test.beforeEach(async ({ page }) => {
             await page.goto(`./components/${component}/${exampleName}`)
+            await page.waitForTimeout(2000)
           })
 
           test('matches the saved screenshot', async ({ componentElement }) => {


### PR DESCRIPTION
Some visual regression tests inconsistently fail when running in GitHub Actions. I think this is because the `govuk-frontend-supported` class is added to the `<body>` when JavaScript is enabled. This takes a second or two to initialise, and Playwright thinks the page has stabilised before the class is applied.