### PR TITLE
deps-dev: update `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4275,10 +4275,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
-      "license": "Apache-2.0",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "dependencies": {
         "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"


### PR DESCRIPTION
`package-lock.json` needed to be updated following the update to `eslint-plugin-unicorn` to resolve the remaining vulnerability