### PR TITLE
fix: Add `shx` to `cp` command in `build:assets:svg` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build": "npm run build:assets && npm run build:css && npm run build:lib && npm run build:client",
     "prebuild:assets": "shx rm -rf dist/assets",
     "build:assets": "ts-node scripts/copy-govuk-static-assets.ts && npm run build:assets:svg",
-    "build:assets:svg": "shx mkdir -p dist/assets/svg && cp src/assets/svg/* dist/assets/svg",
+    "build:assets:svg": "shx mkdir -p dist/assets/svg && shx cp src/assets/svg/* dist/assets/svg",
     "prebuild:client": "shx rm -rf dist/client",
     "build:client": "npm run build:client:umd && npm run build:client:es && npm run build:client:react",
     "build:client:umd": "webpack --config webpack.config.ts",


### PR DESCRIPTION
This command was missing `shx`, causing it to fail on Windows machines